### PR TITLE
Fixed `secureConnection` alias to `secure`

### DIFF
--- a/packages/nodemailer/lib/nodemailer.js
+++ b/packages/nodemailer/lib/nodemailer.js
@@ -29,8 +29,8 @@ module.exports = function (transport, options = {}) {
          *
          * Therefore, we have to alias it here to keep things working
          */
-        if (options.secureConnection === true) {
-            transportOptions.secure = true;
+        if (Object.prototype.hasOwnProperty.call(options, 'secureConnection')) {
+            transportOptions.secure = options.secureConnection;
         }
 
         if (options.service && options.service.toLowerCase() === 'sendmail') {

--- a/packages/nodemailer/test/transporter.test.js
+++ b/packages/nodemailer/test/transporter.test.js
@@ -10,10 +10,16 @@ describe('Transporter', function () {
         transporter.transporter.name.should.equal('SMTP');
     });
 
-    it('can create an SMTP transporter with deprecated secureConnection', function () {
+    it('can create an SMTP transporter with deprecated secureConnection (true)', function () {
         const transporter = nodemailer('SMTP', {secureConnection: true});
         transporter.transporter.name.should.equal('SMTP');
         transporter.transporter.options.secure.should.equal(true);
+    });
+
+    it('can create an SMTP transporter with deprecated secureConnection (false)', function () {
+        const transporter = nodemailer('SMTP', {secureConnection: false});
+        transporter.transporter.name.should.equal('SMTP');
+        transporter.transporter.options.secure.should.equal(false);
     });
 
     it('can create an SMTP transporter with Sendmail service', function () {


### PR DESCRIPTION
refs https://linear.app/tryghost/issue/CORE-66/fixed-secureconnection-alias-for-nodemailer

- I incorrectly only handed the case where `secureConnection` was set to
  `true`, but you can also disable secure transport
- this meant `secureConnection` was `false` but this wouldn't be passed
  through to the library
- this resulted in SSL errors as reported in https://forum.ghost.org/t/un-noticed-email-config-change-in-4-15-16/25869/