### PR TITLE
Include error context in expectStatus message

### DIFF
--- a/packages/express-test/lib/expect-request.js
+++ b/packages/express-test/lib/expect-request.js
@@ -198,6 +198,10 @@ class ExpectRequest extends Request {
 
         if (response.body && response.body.errors && response.body.errors[0].message) {
             error.message += `\n${response.body.errors[0].message}`;
+
+            if (response.body.errors[0].context) {
+                error.message += `\n${response.body.errors[0].context}`;
+            }
         }
 
         error.actual = response.statusCode;

--- a/packages/express-test/test/expect-request.test.js
+++ b/packages/express-test/test/expect-request.test.js
@@ -310,6 +310,33 @@ describe('ExpectRequest', function () {
             assert.throws(assertFn, {message: 'Expected statusCode 200, got statusCode 404 foo\nNot found'});
         });
 
+        it('_assertStatus not ok when status i not ok and shows response context when present', function () {
+            const fn = () => { };
+            const jar = {};
+            const opts = new RequestOptions();
+            const request = new ExpectRequest(fn, jar, opts);
+
+            const error = new assert.AssertionError({});
+            error.contextString = 'foo';
+
+            const response = {
+                statusCode: 500,
+                body: {
+                    errors: [{
+                        message: 'Internal server error, cannot save member.',
+                        context: 'offer is not defined on the model.'
+                    }]
+                }
+            };
+            const assertion = {expected: 200, error};
+
+            const assertFn = () => {
+                request._assertStatus(response, assertion);
+            };
+
+            assert.throws(assertFn, {message: 'Expected statusCode 200, got statusCode 500 foo\nInternal server error, cannot save member.\noffer is not defined on the model.'});
+        });
+
         it('_assertHeader ok when header is ok', function () {
             const fn = () => { };
             const jar = {};


### PR DESCRIPTION
From time to time I stumble on a 500 error when running the tests locally. The message of a 500 error is often quite unhelpful and hard to debug. Having the context (if it is available) would save a lot of time and doesn't increase the test output that much.

Example test output after this change:
```
Expected statusCode 201, got statusCode 500 POST request on /ghost/api/admin/members/
Internal server error, cannot save member.
offer is not defined on the model.
```