### PR TITLE
Updated RequestNotAcceptableError to have no stack

### DIFF
--- a/packages/errors/lib/errors.js
+++ b/packages/errors/lib/errors.js
@@ -175,7 +175,8 @@ const ghostErrors = {
             super(merge({
                 statusCode: 406,
                 errorType: 'RequestNotAcceptableError',
-                message: 'Request not acceptable for provided Accept-Version header.'
+                message: 'Request not acceptable for provided Accept-Version header.',
+                hideStack: true
             }, options));
         }
     },

--- a/packages/errors/test/errors.test.js
+++ b/packages/errors/test/errors.test.js
@@ -430,7 +430,7 @@ Line 2 - Help`);
             error.level.should.eql('normal'),
             error.errorType.should.eql('RequestNotAcceptableError');
             error.message.should.eql('Request not acceptable for provided Accept-Version header.');
-            error.hideStack.should.be.false();
+            error.hideStack.should.be.true();
         });
 
         it('RequestEntityTooLargeError', function () {


### PR DESCRIPTION
- The stacktrace on this error is always useless like on a 404 request