### PR TITLE
Added support for configuring logs to use the local timezone

### DIFF
--- a/packages/logging/lib/GhostLogger.js
+++ b/packages/logging/lib/GhostLogger.js
@@ -30,6 +30,7 @@ class GhostLogger {
      * elasticsearch:   Elasticsearch transport configuration
      * gelf:            Gelf transport configuration.
      * http:            HTTP transport configuration
+     * useLocalTime:    Use local time instead of UTC.
      * @param {object} options Bag of options
      */
     constructor(options) {
@@ -47,6 +48,7 @@ class GhostLogger {
         this.elasticsearch = options.elasticsearch || {};
         this.gelf = options.gelf || {};
         this.http = options.http || {};
+        this.useLocalTime = options.useLocalTime || false;
 
         // CASE: stdout has to be on the first position in the transport,  because if the GhostLogger itself logs, you won't see the stdout print
         if (this.transports.indexOf('stdout') !== -1 && this.transports.indexOf('stdout') !== 0) {
@@ -496,6 +498,12 @@ class GhostLogger {
                 modifiedMessages.push(value);
             }
         });
+
+        if (this.useLocalTime) {
+            let currentDate = new Date();
+            currentDate.setMinutes(currentDate.getMinutes() - currentDate.getTimezoneOffset());
+            modifiedObject.time = currentDate.toISOString();
+        }
 
         if (!isEmpty(modifiedObject)) {
             if (modifiedObject.err) {


### PR DESCRIPTION
For the background on PR, see the following issue: https://github.com/TryGhost/Ghost/issues/15190

To avoid breaking changes, I left the default behavior as is and made it available as an option.

The issue PR is trying to solve was complicated by the following fact:
- bunyan is designed to fix log timezone to UTC. (refs: [bunyan docs](https://github.com/trentm/node-bunyan#core-fields))
- Ghost is fixed moment.js timezone to UTC. (refs: [overrides.js](https://github.com/TryGhost/Ghost/blob/main/ghost/core/core/server/overrides.js))

Additional revision required:
- [defaults.json](https://github.com/TryGhost/Ghost/blob/main/ghost/core/core/shared/config/defaults.json)
- [Ghost Developer docs](https://ghost.org/docs/config/#logging)