### PR TITLE
✨ Added promise pool utility

### DIFF
--- a/packages/promise/index.js
+++ b/packages/promise/index.js
@@ -5,5 +5,9 @@ module.exports = {
 
     get sequence() {
         return require('./lib/sequence');
+    },
+
+    get pool() {
+        return require('./lib/pool');
     }
 };

--- a/packages/promise/lib/pool.js
+++ b/packages/promise/lib/pool.js
@@ -1,0 +1,27 @@
+/**
+ * Promise Pool
+ *
+ * The pool will execute all the tasks with maxConcurrent tasks
+ * running simoultaneously at most. 
+ */
+
+async function pool(tasks, maxConcurrent) {
+    if (maxConcurrent < 1) {
+        throw new Error('Must set at least 1 concurrent workers');
+    }
+
+    const taskIterator = tasks.entries();
+    const results = [];
+ 
+    const workers = Array(maxConcurrent).fill(taskIterator).map(
+        async (workerIterator) => {
+            for (let [index, task] of workerIterator) {
+                results[index] = await task();
+            }
+        }
+    );
+    await Promise.all(workers);
+    return results;
+}
+
+module.exports = pool;

--- a/packages/promise/lib/pool.js
+++ b/packages/promise/lib/pool.js
@@ -2,17 +2,17 @@
  * Promise Pool
  *
  * The pool will execute all the tasks with maxConcurrent tasks
- * running simoultaneously at most. 
+ * running simoultaneously at most.
  */
 
 async function pool(tasks, maxConcurrent) {
     if (maxConcurrent < 1) {
-        throw new Error('Must set at least 1 concurrent workers');
+        throw new Error('Must set at least 1 concurrent workers'); // eslint-disable-line no-restricted-syntax
     }
 
     const taskIterator = tasks.entries();
     const results = [];
- 
+
     const workers = Array(maxConcurrent).fill(taskIterator).map(
         async (workerIterator) => {
             for (let [index, task] of workerIterator) {

--- a/packages/promise/test/pool.test.js
+++ b/packages/promise/test/pool.test.js
@@ -1,0 +1,66 @@
+require('./utils');
+const {promisify} = require('util');
+const {pool} = require('../');
+const assert = require('assert');
+
+describe('Promise pool', function () {
+    it('preserves order', function () {
+        const tasks = [
+            async function a() {
+                await promisify(setTimeout)(100);
+                return Promise.resolve('hello');
+            },
+            function b() {
+                return Promise.resolve('hi');
+            }
+        ];
+        return pool(tasks, 3)
+            .then(function (result) {
+                result.should.eql(['hello','hi']);
+            });
+    });
+
+    it('handles mixed promises and values', function () {
+        const tasks = [
+            async function a() {
+                return 'hello';
+            },
+            function b() {
+                return Promise.resolve('hi');
+            }
+        ];
+        return pool(tasks, 3)
+            .then(function (result) {
+                result.should.eql(['hello','hi']);
+            });
+    });
+
+    it('does not allow less than 1 worker', async function () {
+        const tasks = [
+            async function a() {
+                return 'hello';
+            }
+        ];
+
+        await assert.rejects(pool(tasks, 0), {
+            name: 'Error',
+            message: 'Must set at least 1 concurrent workers'
+        });
+    });
+
+    it('does not affect results to have more workers than tasks', function () {
+        const tasks = [
+            async function a() {
+                return Promise.resolve('hi');
+            },
+            function b() {
+                return Promise.resolve('hello');
+            }
+        ];
+
+        pool(tasks, 100)
+            .then(function (result) {
+                result.should.eql(['hi','hello']);
+            });
+    });
+});


### PR DESCRIPTION
Adds a promise pool functionality to the Ghost Promise package. The pool supports a concurrency parameter to control how many async functions execute simultaneously. Otherwise it works much like `Promise.all`. It takes advantage of the fact that a single iterator is shared between the worker loops. 

This comes in handy when we want to throttle large async operations. With the removal of Bluebird (https://github.com/TryGhost/Ghost/issues/14882) we lose the ability to have a `Promise.map` concurrency option which is used in some places in the Ghost API. 


This code is similar to the following libraries: 

- [es6-promise-pool](https://github.com/timdp/es6-promise-pool)
- [supercharge/promise-pool](https://github.com/supercharge/promise-pool)

I opted for an implementation as opposed to using a library since the code is quite small and neat and it wouldn't feel good to remove Bluebird just to add another dependency :) Fun fact... the base case of the `pool` function with `1` worker should be identical to the `sequence` method. 

