### PR TITLE
Removed used of `fs-extra` from @tryghost/logging

### DIFF
--- a/packages/errors/src/errors.ts
+++ b/packages/errors/src/errors.ts
@@ -137,6 +137,17 @@ export class RequestNotAcceptableError extends GhostError {
     }
 }
 
+export class RangeNotSatisfiableError extends GhostError {
+    constructor(options: GhostErrorOptions = {}) {
+        super(mergeOptions(options, {
+            statusCode: 416,
+            errorType: 'RangeNotSatisfiableError',
+            message: 'Range not satisfiable for provided Range header.',
+            hideStack: true
+        }));
+    }
+}
+
 export class RequestEntityTooLargeError extends GhostError {
     constructor(options: GhostErrorOptions = {}) {
         super(mergeOptions(options, {

--- a/packages/errors/test/errors.test.ts
+++ b/packages/errors/test/errors.test.ts
@@ -488,6 +488,15 @@ Line 2 - Help`);
             error.hideStack.should.be.false();
         });
 
+        it('RangeNotSatisfiableError', function () {
+            const error = new errors.RangeNotSatisfiableError();
+            error.statusCode.should.eql(416);
+            error.level.should.eql('normal');
+            error.errorType.should.eql('RangeNotSatisfiableError');
+            error.message.should.eql('Range not satisfiable for provided Range header.');
+            error.hideStack.should.be.true();
+        });
+
         it('TokenRevocationError', function () {
             const error = new errors.TokenRevocationError();
             error.statusCode.should.eql(503);

--- a/packages/logging/lib/GhostLogger.js
+++ b/packages/logging/lib/GhostLogger.js
@@ -5,7 +5,7 @@ const isObject = require('lodash/isObject');
 const isEmpty = require('lodash/isEmpty');
 const includes = require('lodash/includes');
 const bunyan = require('bunyan');
-const fs = require('fs-extra');
+const fs = require('fs');
 const jsonStringifySafe = require('json-stringify-safe');
 
 /**
@@ -287,7 +287,7 @@ class GhostLogger {
         const sanitizedDomain = this.domain.replace(/[^\w]/gi, '_');
 
         // CASE: target log folder does not exist, show warning
-        if (!fs.pathExistsSync(this.path)) {
+        if (!fs.existsSync(this.path)) {
             this.error('Target log folder does not exist: ' + this.path);
             return;
         }


### PR DESCRIPTION
ref SLO-14
ref https://linear.app/tryghost/issue/SLO-14/improved-speed-of-migratejs-script

- fs-extra can be a really heavy library when you're trying to stay lean
- we don't need it here because `fs` natively comes with a sync `exists` method
- this replaces `fs-extra` with `fs`