### PR TITLE
Added filename length validation when extracting a zip

### DIFF
--- a/packages/zip/lib/extract.js
+++ b/packages/zip/lib/extract.js
@@ -12,15 +12,15 @@ function throwOnSymlinks(entry) {
 
     if (symlink) {
         throw new errors.UnsupportedMediaTypeError({
-            message: 'Symlinks in ZIP-files are not allowed'
+            message: 'Symlinks are not allowed in the zip folder.'
         });
     }
 }
 
 function throwOnLargeFilenames(entry) {
     if (Buffer.byteLength(entry.fileName, 'utf8') >= 254) {
-        throw new errors.IncorrectUsageError({
-            message: 'File names of 254 bytes or more are not allowed'
+        throw new errors.UnsupportedMediaTypeError({
+            message: 'File names in the zip folder must be shorter than 254 characters.'
         });
     }
 }

--- a/packages/zip/test/zip.test.js
+++ b/packages/zip/test/zip.test.js
@@ -102,13 +102,13 @@ describe('Extract zip', function () {
         fs.existsSync(path.join(unzipDestination, 'package.json')).should.be.true();
     });
 
-    it('throws if the zip contains a file with more than 254 bytes or more', async function () {
-        const longFileName = 'a'.repeat(250) + '.txt'; // 254 characters
+    it('throws if the zip contains a filename with 254 or more bytes', async function () {
+        const longFileName = 'a'.repeat(250) + '.txt'; // 254 bytes
         longFilePath = path.join(themeFolder, longFileName);
 
         fs.writeFileSync(longFilePath, 'test content');
 
         await compress(themeFolder, zipDestination);
-        await extract(zipDestination, unzipDestination).should.be.rejectedWith('File names of 254 bytes or more are not allowed');
+        await extract(zipDestination, unzipDestination).should.be.rejectedWith('File names in the zip folder must be shorter than 254 characters.');
     });
 });

--- a/packages/zip/test/zip.test.js
+++ b/packages/zip/test/zip.test.js
@@ -10,7 +10,7 @@ const {hashElement} = require('folder-hash');
 const {compress, extract} = require('../');
 
 describe('Compress and Extract should be opposite functions', function () {
-    let symlinkPath, folderToSymlink, zipDestination, unzipDestination;
+    let symlinkPath, themeFolder, zipDestination, unzipDestination;
 
     const cleanUp = () => {
         fs.removeSync(symlinkPath);
@@ -20,9 +20,9 @@ describe('Compress and Extract should be opposite functions', function () {
 
     before(function () {
         symlinkPath = path.join(__dirname, 'fixtures', 'theme-symlink');
-        folderToSymlink = path.join(__dirname, 'fixtures', 'test-theme');
-        zipDestination = path.join(__dirname, 'fixtures', 'theme-symlink.zip');
-        unzipDestination = path.join(__dirname, 'fixtures', 'theme-symlink-unzipped');
+        themeFolder = path.join(__dirname, 'fixtures', 'test-theme');
+        zipDestination = path.join(__dirname, 'fixtures', 'test-theme.zip');
+        unzipDestination = path.join(__dirname, 'fixtures', 'test-theme-unzipped');
 
         cleanUp();
     });
@@ -32,7 +32,7 @@ describe('Compress and Extract should be opposite functions', function () {
     });
 
     it('ensure symlinks work', function (done) {
-        fs.symlinkSync(folderToSymlink, symlinkPath);
+        fs.symlinkSync(themeFolder, symlinkPath);
 
         let originalHash;
 
@@ -62,5 +62,53 @@ describe('Compress and Extract should be opposite functions', function () {
             .catch((err) => {
                 return done(err);
             });
+    });
+});
+
+describe('Extract zip', function () {
+    let themeFolder, zipDestination, unzipDestination, symLinkPath, longFilePath;
+
+    before(function () {
+        themeFolder = path.join(__dirname, 'fixtures', 'test-theme');
+        zipDestination = path.join(__dirname, 'fixtures', 'test-theme.zip');
+        unzipDestination = path.join(__dirname, 'fixtures', 'test-theme-unzipped');
+        symLinkPath = path.join(__dirname, 'fixtures', 'test-theme-symlink');
+    });
+
+    afterEach(function () {
+        if (fs.existsSync(zipDestination)) {
+            fs.removeSync(zipDestination);
+        }
+
+        if (fs.existsSync(unzipDestination)) {
+            fs.removeSync(unzipDestination);
+        }
+
+        if (fs.existsSync(symLinkPath)) {
+            fs.removeSync(symLinkPath);
+        }
+
+        if (fs.existsSync(longFilePath)) {
+            fs.removeSync(longFilePath);
+        }
+    });
+
+    it('extracts a zip file', async function () {
+        await compress(themeFolder, zipDestination);
+
+        await extract(zipDestination, unzipDestination);
+
+        fs.existsSync(unzipDestination).should.be.true();
+        fs.existsSync(path.join(unzipDestination, 'package.json')).should.be.true();
+    });
+
+    it('throws if the zip contains a file with more than 254 bytes or more', async function () {
+        const longFileName = 'a'.repeat(250) + '.txt'; // 254 characters
+        longFilePath = path.join(themeFolder, longFileName);
+
+        fs.writeFileSync(longFilePath, 'test content');
+
+        await compress(themeFolder, zipDestination);
+        await extract(zipDestination, unzipDestination).should.be.rejectedWith('File names of 254 bytes or more are not allowed');
     });
 });


### PR DESCRIPTION
ref https://linear.app/tryghost/issue/ENG-842/gluster-file-name-length-limit

- filesystems such as Unix or Gluster do not support file names that are longer than 255 bytes
- when extracting a zip (e.g. for a theme upload), we now run a validation over the filenames of the zipped folder. If any file has a name of 254 or more bytes, the zip extraction will throw an error