### PR TITLE
Optimized various hotpaths in logging + pretty-stream packages

### DIFF
--- a/packages/logging/lib/GhostLogger.js
+++ b/packages/logging/lib/GhostLogger.js
@@ -459,7 +459,8 @@ class GhostLogger {
     removeSensitiveData(obj) {
         let newObj = {};
 
-        each(obj, (value, key) => {
+        for (const key in obj) {
+            let value = obj[key];
             try {
                 if (isObject(value)) {
                     value = this.removeSensitiveData(value);
@@ -473,7 +474,7 @@ class GhostLogger {
             } catch (err) {
                 newObj[key] = value;
             }
-        });
+        }
 
         return newObj;
     }

--- a/packages/pretty-stream/lib/PrettyStream.js
+++ b/packages/pretty-stream/lib/PrettyStream.js
@@ -3,12 +3,13 @@ const Transform = require('stream').Transform;
 const format = require('util').format;
 const prettyjson = require('prettyjson');
 const each = require('lodash/each');
-const omit = require('lodash/omit');
 const get = require('lodash/get');
 const isArray = require('lodash/isArray');
 const isEmpty = require('lodash/isEmpty');
 const isObject = require('lodash/isObject');
-const isString = require('lodash/isString');
+
+const OMITTED_KEYS = ['time', 'level', 'name', 'hostname', 'pid', 'v', 'msg'];
+
 const _private = {
     levelFromName: {
         10: 'trace',
@@ -83,7 +84,7 @@ class PrettyStream extends Transform {
     }
 
     _transform(data, enc, cb) {
-        if (!isString(data)) {
+        if (typeof data !== 'string') {
             data = data.toString();
         }
 
@@ -125,7 +126,7 @@ class PrettyStream extends Transform {
             output += format('[%s] %s %s\n', time, logLevel, bodyPretty);
         }
 
-        each(omit(data, ['time', 'level', 'name', 'hostname', 'pid', 'v', 'msg']), function (value, key) {
+        each(Object.fromEntries(Object.entries(data).filter(([key]) => !OMITTED_KEYS.includes(key))), function (value, key) {
             // we always output errors for now
             if (isObject(value) && value.message && value.stack) {
                 let error = '\n';


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PRO-1359/improve-ghost-performance-by-removing-logging-to-stdout

- we've discovered various bottlenecks when writing logs at high traffic times, and there are a few hot codepaths that are easily fixable by switching out lodash for native functions
- this speeds up writing logs via stdout by ~13% (it varies depending on what body you're using)
- also has a marginal boost to file-based logging, but that's mostly limited by JSON.stringify