### PR TITLE
Improved stdout logging performance by removing moment.js

### DIFF
--- a/packages/pretty-stream/lib/PrettyStream.js
+++ b/packages/pretty-stream/lib/PrettyStream.js
@@ -1,4 +1,4 @@
-const moment = require('moment');
+const dateFormat = require('date-format');
 const Transform = require('stream').Transform;
 const format = require('util').format;
 const prettyjson = require('prettyjson');
@@ -100,7 +100,19 @@ class PrettyStream extends Transform {
         }
 
         let output = '';
-        const time = moment(data.time).format('YYYY-MM-DD HH:mm:ss');
+
+        // Convert the time to UTC
+        const now = new Date();
+        const dataTime = new Date(data.time);
+
+        // If the timezone offset is equal to the current timezone offset, and that timezone offset is not 0,
+        // then we need to adjust the time
+        if (dataTime.getTimezoneOffset() === now.getTimezoneOffset() && dataTime.getTimezoneOffset() !== 0) {
+            dataTime.setMinutes(dataTime.getMinutes() + dataTime.getTimezoneOffset());
+        }
+
+        const time = dateFormat.asString('yyyy-MM-dd hh:mm:ss', dataTime);
+
         let logLevel = _private.levelFromName[data.level].toUpperCase();
         const codes = _private.colors[_private.colorForLevel[data.level]];
         let bodyPretty = '';

--- a/packages/pretty-stream/package.json
+++ b/packages/pretty-stream/package.json
@@ -25,8 +25,8 @@
     "sinon": "18.0.0"
   },
   "dependencies": {
+    "date-format": "^4.0.14",
     "lodash": "^4.17.21",
-    "moment": "^2.29.1",
     "prettyjson": "^1.2.5"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3876,6 +3876,11 @@ date-fns@^2.28.0:
   dependencies:
     "@babel/runtime" "^7.21.0"
 
+date-format@^4.0.14:
+  version "4.0.14"
+  resolved "https://registry.yarnpkg.com/date-format/-/date-format-4.0.14.tgz#7a8e584434fb169a521c8b7aa481f355810d9400"
+  integrity sha512-39BOQLs9ZjKh0/patS9nrT8wc3ioX3/eA/zgbKNopnF2wCqJEoxywwwElATYvRsXdnOxA/OQeQoFZ3rFjVajhg==
+
 debug@2.6.9, debug@^2.1.3, debug@^2.2.0, debug@^2.6.8, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
@@ -4368,7 +4373,6 @@ eslint-plugin-es-x@^7.1.0:
 
 eslint-plugin-filenames@allouis/eslint-plugin-filenames#15dc354f4e3d155fc2d6ae082dbfc26377539a18:
   version "1.3.2"
-  uid "15dc354f4e3d155fc2d6ae082dbfc26377539a18"
   resolved "https://codeload.github.com/allouis/eslint-plugin-filenames/tar.gz/15dc354f4e3d155fc2d6ae082dbfc26377539a18"
   dependencies:
     lodash.camelcase "4.3.0"
@@ -6770,7 +6774,7 @@ moment-timezone@^0.5.23, moment-timezone@^0.5.33:
   dependencies:
     moment "^2.29.4"
 
-moment@^2.18.1, moment@^2.19.3, moment@^2.29.1, moment@^2.29.4:
+moment@^2.18.1, moment@^2.19.3, moment@^2.29.4:
   version "2.30.1"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.30.1.tgz#f8c91c07b7a786e30c59926df530b4eac96974ae"
   integrity sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==


### PR DESCRIPTION
fix https://linear.app/ghost/issue/ENG-2005/improve-stdout-logging-performance

- this section of the code generates a formatted string of the current datetime, so we can output it in the stdout logs
- the problem is, moment is a very heavy library and we're seeing a huge performance hit during high traffic/logging moments
- the bulk of this problem is caused by moment, so working to remove it should improve performance
- this commit replaces momeny with `date-format`, which operates on Date objects
- sadly, the change is not the _most_ straightforward because our use of moment ensures it's always in UTC, but Date converts datetimes into the local timezone
- to workaround that, we can shift the datetime by the timezone offset from UTC, if present
- this ensures all tests continue to pass and we get the correct datetime locally
- this commit improves performance by 2x for logging to stdout (it's still slower than file-based logging though)