### PR TITLE
Added new attach helper for sending formdata

### DIFF
--- a/packages/express-test/lib/Request.js
+++ b/packages/express-test/lib/Request.js
@@ -1,7 +1,7 @@
 const {default: reqresnext} = require('reqresnext');
 const {CookieAccessInfo} = require('cookiejar');
 const {parse} = require('url');
-const {isJSON} = require('./utils');
+const {isJSON, attachFile} = require('./utils');
 const {Readable} = require('stream');
 
 class RequestOptions {
@@ -22,6 +22,11 @@ class Request {
         this.app = app;
         this.reqOptions = reqOptions instanceof RequestOptions ? reqOptions : new RequestOptions(reqOptions);
         this.cookieJar = cookieJar;
+    }
+
+    attach(name, filePath) {
+        const formData = attachFile(name, filePath);
+        return this.body(formData);
     }
 
     /**

--- a/packages/express-test/lib/utils.js
+++ b/packages/express-test/lib/utils.js
@@ -1,7 +1,12 @@
-module.exports.isJSON = function isJSON(mime) {
+const fs = require('fs');
+const path = require('path');
+const mime = require('mime-types');
+const FormData = require('form-data');
+
+module.exports.isJSON = function isJSON(mimeType) {
     // should match /json or +json
     // but not /json-seq
-    return /[/+]json($|[^-\w])/i.test(mime);
+    return /[/+]json($|[^-\w])/i.test(mimeType);
 };
 
 module.exports.normalizeURL = function normalizeURL(toNormalize) {
@@ -14,4 +19,18 @@ module.exports.normalizeURL = function normalizeURL(toNormalize) {
     }
 
     return normalized;
+};
+
+module.exports.attachFile = function attachFile(name, filePath) {
+    const formData = new FormData();
+    const fileContent = fs.readFileSync(filePath);
+    const filename = path.basename(filePath);
+    const contentType = mime.lookup(filePath) || 'application/octet-stream';
+
+    formData.append(name, fileContent, {
+        filename,
+        contentType
+    });
+
+    return formData;
 };

--- a/packages/express-test/package.json
+++ b/packages/express-test/package.json
@@ -22,7 +22,6 @@
     "c8": "10.1.3",
     "express": "4.21.1",
     "express-session": "1.18.1",
-    "form-data": "^4.0.0",
     "mocha": "10.7.3",
     "multer": "^1.4.5-lts.1",
     "sinon": "18.0.0"
@@ -30,6 +29,8 @@
   "dependencies": {
     "@tryghost/jest-snapshot": "^0.5.17",
     "cookiejar": "^2.1.3",
+    "form-data": "^4.0.2",
+    "mime-types": "^3.0.1",
     "reqresnext": "^1.7.0"
   }
 }

--- a/packages/express-test/test/example-app.test.js
+++ b/packages/express-test/test/example-app.test.js
@@ -360,6 +360,31 @@ describe('Example App', function () {
             }
         });
 
+        it('can upload a file using the attach method', async function () {
+            const fileContents = await fs.readFile(__dirname + '/fixtures/ghost-favicon.png');
+
+            const {body} = await agent
+                .post('/api/upload/')
+                .attach('image', __dirname + '/fixtures/ghost-favicon.png')
+                .expectStatus(200);
+
+            assert.equal(body.originalname, 'ghost-favicon.png');
+            assert.equal(body.mimetype, 'image/png');
+            assert.equal(body.size, fileContents.length);
+            assert.equal(body.fieldname, 'image');
+
+            // Do a real comparison in the uploaded file to check if it was uploaded and saved correctly
+            const uploadedFileContents = await fs.readFile(body.path);
+            assert.deepEqual(uploadedFileContents, fileContents);
+
+            // Delete the file
+            try {
+                await fs.unlink(body.path);
+            } catch (e) {
+                // ignore if this fails
+            }
+        });
+
         it('can stream body', async function () {
             const stat = await fs.stat(__dirname + '/fixtures/long-json-body.json');
             const stream = createReadStream(__dirname + '/fixtures/long-json-body.json');

--- a/packages/express-test/test/fixtures/test-file.txt
+++ b/packages/express-test/test/fixtures/test-file.txt
@@ -1,0 +1,1 @@
+test content for file upload

--- a/packages/express-test/test/utils.test.js
+++ b/packages/express-test/test/utils.test.js
@@ -1,6 +1,8 @@
 const {assert} = require('./utils');
+const path = require('path');
+const FormData = require('form-data');
 
-const {isJSON, normalizeURL} = require('../lib/utils');
+const {isJSON, normalizeURL, attachFile} = require('../lib/utils');
 
 describe('Utils', function () {
     it('isJSON', function () {
@@ -28,6 +30,92 @@ describe('Utils', function () {
         it('does NOT add trailing slash in the end of URL respecting query string', function () {
             const url = normalizeURL('http://example.com/?yolo=9000');
             assert.equal(url, 'http://example.com/?yolo=9000');
+        });
+    });
+
+    describe('attachFile', function () {
+        it('creates FormData with file content', function () {
+            const filePath = path.join(__dirname, 'fixtures/test-file.txt');
+            const formData = attachFile('testfile', filePath);
+
+            assert.equal(formData instanceof FormData, true);
+            assert.equal(typeof formData.getHeaders, 'function');
+            assert.equal(typeof formData.getBuffer, 'function');
+        });
+
+        it('sets correct filename from path', function () {
+            const filePath = path.join(__dirname, 'fixtures/test-file.txt');
+            const formData = attachFile('testfile', filePath);
+
+            // FormData doesn't expose a direct way to check the filename,
+            // but we can verify it was created without errors
+            const headers = formData.getHeaders();
+            assert.match(headers['content-type'], /^multipart\/form-data; boundary=/);
+        });
+
+        it('sets correct content type for text file', function () {
+            const filePath = path.join(__dirname, 'fixtures/test-file.txt');
+            const formData = attachFile('testfile', filePath);
+
+            // Get the form data buffer to check it contains the right content type
+            const buffer = formData.getBuffer();
+            const content = buffer.toString();
+
+            // Check that the form data contains the expected content type
+            assert.match(content, /Content-Type: text\/plain/);
+        });
+
+        it('sets correct content type for PNG image', function () {
+            const filePath = path.join(__dirname, 'fixtures/ghost-favicon.png');
+            const formData = attachFile('image', filePath);
+
+            // Get the form data buffer to check it contains the right content type
+            const buffer = formData.getBuffer();
+            const content = buffer.toString();
+
+            // Check that the form data contains the expected content type
+            assert.match(content, /Content-Type: image\/png/);
+        });
+
+        it('uses default content type for unknown file extension', function () {
+            // Create a file with unknown extension
+            const fs = require('fs');
+            const unknownFile = path.join(__dirname, 'fixtures/test.unknown');
+            fs.writeFileSync(unknownFile, 'test content');
+
+            try {
+                const formData = attachFile('file', unknownFile);
+                const buffer = formData.getBuffer();
+                const content = buffer.toString();
+
+                // Check that the form data contains the default content type
+                assert.match(content, /Content-Type: application\/octet-stream/);
+            } finally {
+                // Clean up
+                fs.unlinkSync(unknownFile);
+            }
+        });
+
+        it('includes the correct field name', function () {
+            const filePath = path.join(__dirname, 'fixtures/test-file.txt');
+            const formData = attachFile('myfield', filePath);
+
+            const buffer = formData.getBuffer();
+            const content = buffer.toString();
+
+            // Check that the form data contains the field name
+            assert.match(content, /Content-Disposition: form-data; name="myfield"/);
+        });
+
+        it('includes the file content', function () {
+            const filePath = path.join(__dirname, 'fixtures/test-file.txt');
+            const formData = attachFile('testfile', filePath);
+
+            const buffer = formData.getBuffer();
+            const content = buffer.toString();
+
+            // Check that the form data contains the file content
+            assert.match(content, /test content for file upload/);
         });
     });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -5241,7 +5241,7 @@ form-data-encoder@^2.1.2:
   resolved "https://registry.yarnpkg.com/form-data-encoder/-/form-data-encoder-2.1.4.tgz#261ea35d2a70d48d30ec7a9603130fa5515e9cd5"
   integrity sha512-yDYSgNMraqvnxiEXO4hi88+YZxaHC6QKzb5N84iRCTDeRO7ZALpir/lVmf/uXUhnwUr2O4HU8s/n6x+yNjQkHw==
 
-form-data@^4.0.0:
+form-data@^4.0.0, form-data@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.2.tgz#35cabbdd30c3ce73deb2c42d3c8d3ed9ca51794c"
   integrity sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==
@@ -7067,12 +7067,24 @@ mime-db@1.52.0:
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
   integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
 
+mime-db@^1.54.0:
+  version "1.54.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.54.0.tgz#cddb3ee4f9c64530dff640236661d42cb6a314f5"
+  integrity sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==
+
 mime-types@^2.1.12, mime-types@~2.1.19, mime-types@~2.1.24, mime-types@~2.1.34:
   version "2.1.35"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
   integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
   dependencies:
     mime-db "1.52.0"
+
+mime-types@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-3.0.1.tgz#b1d94d6997a9b32fd69ebaed0db73de8acb519ce"
+  integrity sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==
+  dependencies:
+    mime-db "^1.54.0"
 
 mime@1.6.0:
   version "1.6.0"


### PR DESCRIPTION
- If you want to send formdata via the body() method you can
- But this requires using the formdata API correctly yourself
- Note: the form-data module and Native FormData api aren't compatible
- This new helper allows you to attach files using the same API as supertest
- This will result in easier-to-read tests with less dependencies