### PR TITLE
Added multiple file support to attach helper

### DIFF
--- a/packages/express-test/example/app.js
+++ b/packages/express-test/example/app.js
@@ -76,4 +76,11 @@ app.post('/api/upload/', upload.single('image'), async (req, res) => {
     return res.json(req.file);
 });
 
+app.post('/api/upload-multiple/', upload.fields([
+    {name: 'image', maxCount: 1},
+    {name: 'document', maxCount: 1}
+]), async (req, res) => {
+    return res.json(req.files);
+});
+
 module.exports = app;

--- a/packages/express-test/lib/Request.js
+++ b/packages/express-test/lib/Request.js
@@ -22,11 +22,15 @@ class Request {
         this.app = app;
         this.reqOptions = reqOptions instanceof RequestOptions ? reqOptions : new RequestOptions(reqOptions);
         this.cookieJar = cookieJar;
+        this._formData = null; // Track FormData instance for multiple attachments
     }
 
     attach(name, filePath) {
-        const formData = attachFile(name, filePath);
-        return this.body(formData);
+        // Use the utility to create or append to FormData
+        this._formData = attachFile(name, filePath, this._formData);
+
+        // Set the body to the FormData instance
+        return this.body(this._formData);
     }
 
     /**

--- a/packages/express-test/lib/utils.js
+++ b/packages/express-test/lib/utils.js
@@ -21,8 +21,8 @@ module.exports.normalizeURL = function normalizeURL(toNormalize) {
     return normalized;
 };
 
-module.exports.attachFile = function attachFile(name, filePath) {
-    const formData = new FormData();
+module.exports.attachFile = function attachFile(name, filePath, existingFormData = null) {
+    const formData = existingFormData || new FormData();
     const fileContent = fs.readFileSync(filePath);
     const filename = path.basename(filePath);
     const contentType = mime.lookup(filePath) || 'application/octet-stream';

--- a/packages/express-test/test/utils.test.js
+++ b/packages/express-test/test/utils.test.js
@@ -117,5 +117,39 @@ describe('Utils', function () {
             // Check that the form data contains the file content
             assert.match(content, /test content for file upload/);
         });
+
+        it('can append to existing FormData', function () {
+            const filePath1 = path.join(__dirname, 'fixtures/test-file.txt');
+            const filePath2 = path.join(__dirname, 'fixtures/ghost-favicon.png');
+
+            // Create FormData with first file
+            const formData = attachFile('file1', filePath1);
+
+            // Append second file to same FormData
+            const updatedFormData = attachFile('file2', filePath2, formData);
+
+            // Should be the same instance
+            assert.equal(formData, updatedFormData);
+
+            // Verify both files are in the FormData
+            const buffer = formData.getBuffer();
+            const content = buffer.toString();
+
+            assert.match(content, /Content-Disposition: form-data; name="file1"/);
+            assert.match(content, /filename="test-file.txt"/);
+            assert.match(content, /Content-Disposition: form-data; name="file2"/);
+            assert.match(content, /filename="ghost-favicon.png"/);
+        });
+
+        it('creates new FormData when existingFormData is null', function () {
+            const filePath = path.join(__dirname, 'fixtures/test-file.txt');
+            const formData = attachFile('testfile', filePath, null);
+
+            assert.equal(formData instanceof FormData, true);
+
+            const buffer = formData.getBuffer();
+            const content = buffer.toString();
+            assert.match(content, /Content-Disposition: form-data; name="testfile"/);
+        });
     });
 });


### PR DESCRIPTION
ref https://github.com/TryGhost/framework/commit/1b6e988437749d61272d737b5fd57cc52f0eb68b

- The new attach helper was working well, but only allowed one file at a time
- We have usecases for multiple files, so this extends the attach helper to support multiple files
- It supports the exact same API as supertest using .attach(name, path) multiple times