### PR TITLE
Fixed usage of assert()

### DIFF
--- a/packages/bookshelf-transaction-events/test/bookshelf-transaction-events.test.js
+++ b/packages/bookshelf-transaction-events/test/bookshelf-transaction-events.test.js
@@ -31,7 +31,7 @@ describe('Bookshelf transaction events', function () {
 
         await trx.commit();
 
-        assert(trx.isCompleted());
-        assert(trx.commit.calledBefore(trx.emit));
+        assert.ok(trx.isCompleted());
+        assert.ok(trx.commit.calledBefore(trx.emit));
     });
 });


### PR DESCRIPTION
- For consistency and clarity we always use a method call with assert
- This is an eslint rule, it's failing for me locally but not on CI for some strange reason

