### PR TITLE
Fixed prettystream timezone handling

### DIFF
--- a/packages/pretty-stream/lib/PrettyStream.js
+++ b/packages/pretty-stream/lib/PrettyStream.js
@@ -101,17 +101,23 @@ class PrettyStream extends Transform {
 
         let output = '';
 
-        // Convert the time to UTC
-        const now = new Date();
-        const dataTime = new Date(data.time || now);
+        // Handle time formatting
+        let time;
 
-        // If the timezone offset is equal to the current timezone offset, and that timezone offset is not 0,
-        // then we need to adjust the time
-        if (dataTime.getTimezoneOffset() === now.getTimezoneOffset() && dataTime.getTimezoneOffset() !== 0) {
-            dataTime.setMinutes(dataTime.getMinutes() + dataTime.getTimezoneOffset());
+        if (data.time) {
+            // If time is provided as a string in the expected format, use it directly
+            if (typeof data.time === 'string' && /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/.test(data.time)) {
+                time = data.time;
+            } else {
+                // Otherwise, parse and format it
+                const dataTime = new Date(data.time);
+                time = dateFormat.asString('yyyy-MM-dd hh:mm:ss', dataTime);
+            }
+        } else {
+            // No time provided, use current time
+            const now = new Date();
+            time = dateFormat.asString('yyyy-MM-dd hh:mm:ss', now);
         }
-
-        const time = dateFormat.asString('yyyy-MM-dd hh:mm:ss', dataTime);
 
         let logLevel = _private.levelFromName[data.level].toUpperCase();
         const codes = _private.colors[_private.colorForLevel[data.level]];


### PR DESCRIPTION
ref https://github.com/TryGhost/framework/commit/be5ddf25873826ae1ede06cae76f6c303eb32b73
- The tests for PrettyStream are failing for me locally with incorrect timestamps
- It seems there was an issue introduced with the refactor to remove moment The code adds the timezone offset, instead of subtracting it, moving it further from UTCi
- This change does the following:
    - If a timestamp is provided in the exact format YYYY-MM-DD HH:mm:ss, use it as-is without any timezone conversion
    - For other timestamp formats (ISO 8601, etc.), parse them with new Date() and format them using date-format
    - When no timestamp is provided, use the current local time
- This approach:
    - Fixes the timezone bug where timestamps were being shifted incorrectly
    - Maintains backward compatibility with existing tests
    - Seemingly works correctly in all timezones (UTC and non-UTC)
    - Includes comprehensive tests to prevent regression
- It's quite hard to reason about the history of this code and what it was intended for so this change also includes extensive futher test coverage to try to enusre this doesn't regress again.