### PR TITLE
docs: Document what Ghost's nodemailer wrapper is doing.

### DIFF
--- a/packages/nodemailer/README.md
+++ b/packages/nodemailer/README.md
@@ -1,16 +1,31 @@
 # Nodemailer
 
-## Install
+This is a wrapper around the [nodemailer](https://nodemailer.com/) module for use internally by [Ghost](https://ghost.org/). It is not intended to be installed or used outside of Ghost.
 
-`npm install @tryghost/nodemailer --save`
+See the [official docs for configurating transaction email sending for Ghost](https://ghost.org/docs/config/#mail).
 
-or
+## Description
 
-`yarn add @tryghost/nodemailer`
+Provides pre-configured transport options for common transport services.
 
+### Supported Transport Types
 
-## Usage
+1. `smtp` - send via SMTP server.
+  *  Detects when service: 'sendmail' is used and enables sendmail mode
 
+2. `mailgun` - Allows using Mailgun with API key instead of via SMTP.
+  *  `auth: { api_key: 'your-mailgun-api-key' }`
+  * Defaults to 60-second timeout.
+
+3. `sendmail` - use local sendmail binary.
+
+4. `ses` - [Send via AWS SES](https://ghost.org/docs/config/#amazon-ses).
+
+5. `direct` - Attempt to connect directly to remote SMTP servers. This is the default and requires no configuration, but is more likely to be blocked by remote mail services.
+
+6. `stub` - For testing and development. Doesn't actually send mail.
+
+Other Nodemailer transports are not supported.
 
 ## Develop
 


### PR DESCRIPTION
Module are kept concise and point readers to official Ghost mail config
docs for configuration details.
