### PR TITLE
Added support for jsonc in `@tryghost/config`

### DIFF
--- a/packages/config/lib/get-config.js
+++ b/packages/config/lib/get-config.js
@@ -2,8 +2,33 @@ const nconf = require('nconf');
 const fs = require('fs');
 const path = require('path');
 const rootUtils = require('@tryghost/root-utils');
+const {parse: parseJsonc} = require('jsonc-parser');
 
 const env = process.env.NODE_ENV || 'development';
+
+function loadJsonOrJsonc(filePath) {
+    if (!fs.existsSync(filePath)) {
+        return null;
+    }
+    
+    const content = fs.readFileSync(filePath, 'utf8');
+    return parseJsonc(content);
+}
+
+function findConfigFile(parentPath, baseName) {
+    // Try .json first for backward compatibility, then .jsonc
+    const jsonPath = path.join(parentPath, baseName + '.json');
+    const jsoncPath = path.join(parentPath, baseName + '.jsonc');
+    
+    if (fs.existsSync(jsonPath)) {
+        return jsonPath;
+    }
+    if (fs.existsSync(jsoncPath)) {
+        return jsoncPath;
+    }
+    
+    return null;
+}
 
 module.exports = function getConfig() {
     const defaults = {};
@@ -11,17 +36,32 @@ module.exports = function getConfig() {
 
     const config = new nconf.Provider();
 
-    if (parentPath && fs.existsSync(path.join(parentPath, 'config.example.json'))) {
-        Object.assign(defaults, require(path.join(parentPath, 'config.example.json')));
+    // Load example config (supports both .json and .jsonc)
+    if (parentPath) {
+        const exampleConfigPath = findConfigFile(parentPath, 'config.example');
+        if (exampleConfigPath) {
+            const exampleConfig = loadJsonOrJsonc(exampleConfigPath);
+            if (exampleConfig) {
+                Object.assign(defaults, exampleConfig);
+            }
+        }
     }
 
     config.argv()
         .env({
             separator: '__'
-        })
-        .file({
-            file: path.join(parentPath, 'config.' + env + '.json')
         });
+
+    // Load environment-specific config (supports both .json and .jsonc)
+    if (parentPath) {
+        const envConfigPath = findConfigFile(parentPath, 'config.' + env);
+        if (envConfigPath) {
+            const envConfig = loadJsonOrJsonc(envConfigPath);
+            if (envConfig) {
+                config.overrides(envConfig);
+            }
+        }
+    }
 
     config.set('env', env);
 

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -30,6 +30,7 @@
   },
   "dependencies": {
     "@tryghost/root-utils": "^0.3.33",
+    "jsonc-parser": "3.3.1",
     "nconf": "^0.12.0"
   }
 }

--- a/packages/config/test/config.test.js
+++ b/packages/config/test/config.test.js
@@ -29,9 +29,64 @@ describe('Config', function () {
         sandbox.stub(rootUtils, 'getProcessRoot').returns(fixturePath());
         var config = getConfig();
 
-        config.stores.file.file.should.endWith('config/test/fixtures/config.testing.json');
         config.get('hello').should.equal('world');
         config.get('test').should.equal('root-config');
         config.get('should-be-used').should.be.true();
+    });
+
+    it('Reads JSONC configuration files with comments', function () {
+        // Create a separate fixture directory for JSONC testing
+        const fs = require('fs');
+        const path = require('path');
+        const jsoncFixturePath = fixturePath('jsonc');
+        
+        // Clean up and create directory
+        if (fs.existsSync(jsoncFixturePath)) {
+            fs.rmSync(jsoncFixturePath, {recursive: true, force: true});
+        }
+        fs.mkdirSync(jsoncFixturePath, {recursive: true});
+        
+        // Copy existing JSONC fixtures to the test directory
+        fs.copyFileSync(fixturePath('config.example.jsonc'), path.join(jsoncFixturePath, 'config.example.jsonc'));
+        fs.copyFileSync(fixturePath('config.testing.jsonc'), path.join(jsoncFixturePath, 'config.testing.jsonc'));
+        
+        sandbox.stub(rootUtils, 'getProcessRoot').returns(jsoncFixturePath);
+        var config = getConfig();
+
+        config.get('hello').should.equal('world');
+        config.get('test').should.equal('root-config-jsonc');
+        config.get('should-be-used').should.be.true();
+        config.get('jsonc').should.be.true();
+        config.get('jsonc-feature').should.equal('enabled');
+        
+        // Clean up
+        fs.rmSync(jsoncFixturePath, {recursive: true, force: true});
+    });
+
+    it('Prefers JSON files over JSONC files when both exist for backward compatibility', function () {
+        const fs = require('fs');
+        const path = require('path');
+        const mixedFixturePath = fixturePath('mixed');
+        
+        // Clean up and create directory
+        if (fs.existsSync(mixedFixturePath)) {
+            fs.rmSync(mixedFixturePath, {recursive: true, force: true});
+        }
+        fs.mkdirSync(mixedFixturePath, {recursive: true});
+        
+        // Create both JSON and JSONC files
+        fs.copyFileSync(fixturePath('config.testing.json'), path.join(mixedFixturePath, 'config.testing.json'));
+        fs.copyFileSync(fixturePath('config.testing.jsonc'), path.join(mixedFixturePath, 'config.testing.jsonc'));
+        
+        sandbox.stub(rootUtils, 'getProcessRoot').returns(mixedFixturePath);
+        var config = getConfig();
+
+        // Should load from JSON file for backward compatibility (has "root-config" value)
+        config.get('test').should.equal('root-config');
+        config.get('should-be-used').should.be.true();
+        should(config.get('jsonc-feature')).be.undefined();
+        
+        // Clean up
+        fs.rmSync(mixedFixturePath, {recursive: true, force: true});
     });
 });

--- a/packages/config/test/fixtures/config.example.jsonc
+++ b/packages/config/test/fixtures/config.example.jsonc
@@ -1,0 +1,10 @@
+{
+    // This is an example config with comments
+    "hello": "world",
+    "test": "overriden", // inline comment
+    /* 
+     * Multi-line comment
+     * for additional configuration
+     */
+    "jsonc": true
+}

--- a/packages/config/test/fixtures/config.testing.jsonc
+++ b/packages/config/test/fixtures/config.testing.jsonc
@@ -1,0 +1,7 @@
+{
+  // Environment specific config with comments
+  "test": "root-config-jsonc",
+  "should-be-used": true,
+  // Support for additional features
+  "jsonc-feature": "enabled"
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -6631,6 +6631,11 @@ json5@^2.2.3:
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
   integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==
 
+jsonc-parser@3.3.1:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/jsonc-parser/-/jsonc-parser-3.3.1.tgz#f2a524b4f7fd11e3d791e559977ad60b98b798b4"
+  integrity sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==
+
 jsonfile@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-4.0.0.tgz#8771aae0799b64076b76640fca058f9c10e33ecb"


### PR DESCRIPTION
It would often be nice to add comments to our configuration files to make them self-documenting. Currently `@tryghost/config` only parses plain json files, which don't allow comments. This adds support for the `.jsonc` file type with backwards compatibility for plain json files.

The implementation will prefer plain `.json` files if both are present for backwards compatibility, which means consuming apps will need to change their current `.json` files to `.jsonc`, rather than adding both. This is as simple as changing the file extension, and then adding comments to the file.