### PR TITLE
Added clearCookies() method to Agent

### DIFF
--- a/packages/express-test/README.md
+++ b/packages/express-test/README.md
@@ -37,6 +37,19 @@ return await agent
         assert.deepEqual(body, {foo: 'bar'});
     });
 ```
+
+### Cookie Management
+
+The agent maintains cookies across requests using a cookie jar. You can clear all cookies (useful for testing authentication flows):
+
+```javascript
+// Clear all cookies
+agent.clearCookies();
+
+// Both methods support chaining
+await agent.logout().get('/protected-route');
+```
+
 This is an initial version for review. More docs coming if it works :)
 
 

--- a/packages/express-test/lib/Agent.js
+++ b/packages/express-test/lib/Agent.js
@@ -91,6 +91,15 @@ class Agent {
             body: Object.assign({}, this.defaults.body, options.body)
         });
     }
+
+    /**
+     * Clear all cookies from the agent's cookie jar
+     * @returns {Agent} - Returns this for chaining
+     */
+    clearCookies() {
+        this.jar = new CookieJar();
+        return this;
+    }
 }
 
 ['get', 'post', 'put', 'patch', 'delete', 'options', 'head'].forEach((method) => {

--- a/packages/express-test/test/Agent.test.js
+++ b/packages/express-test/test/Agent.test.js
@@ -232,5 +232,30 @@ describe('Agent', function () {
             assert.deepEqual(test.reqOptions.headers, {});
             assert.deepEqual(test.reqOptions.body, {});
         });
+
+        it('clearCookies creates a new CookieJar and returns agent for chaining', function () {
+            const fn = () => { };
+            const opts = {};
+            const agent = new Agent(fn, opts);
+
+            const originalJar = agent.jar;
+            const result = agent.clearCookies();
+
+            assert.notEqual(agent.jar, originalJar, 'Should create a new CookieJar instance');
+            assert.equal(result, agent, 'Should return agent for chaining');
+            assert.equal(typeof agent.jar.setCookie, 'function', 'New jar should be a valid CookieJar');
+        });
+
+        it('clearCookies can be chained with other methods', function () {
+            const fn = () => { };
+            const opts = {};
+            const agent = new Agent(fn, opts);
+
+            const request = agent.clearCookies().get('/');
+
+            assert.equal(request instanceof require('../lib/ExpectRequest'), true);
+            assert.equal(request.reqOptions.method, 'GET');
+            assert.equal(request.reqOptions.url, '/');
+        });
     });
 });


### PR DESCRIPTION
- I keep running into issues with Ghost tests when using an API key after having logged in with a cookie session - it seems like it's working but the cookie hangs around and gets used
- Maybe we should be creating new agents each time but that feels superfluous to me
- Instead, I want to be able to discard any existing authentication when an authentication method is called on an Agent
- By adding a clearCookie() method, I can clear any existing cookies when switching to API auth