### PR TITLE
Added @tryghost/anomalies package with initial implementation

### DIFF
--- a/packages/anomalies/.eslintrc.js
+++ b/packages/anomalies/.eslintrc.js
@@ -1,0 +1,7 @@
+module.exports = {
+    parser: '@typescript-eslint/parser',
+    plugins: ['ghost'],
+    extends: [
+        'plugin:ghost/node'
+    ]
+};

--- a/packages/anomalies/LICENSE
+++ b/packages/anomalies/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2013-2025 Ghost Foundation
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/anomalies/README.md
+++ b/packages/anomalies/README.md
@@ -1,0 +1,132 @@
+# Anomalies
+
+Simple, categorical errors designed to be actionable
+
+Based on the [Cognitect Labs anomalies library](https://github.com/cognitect-labs/anomalies/tree/master)
+
+## Install
+
+`npm install @tryghost/anomalies --save`
+
+or
+
+`yarn add @tryghost/anomalies`
+
+## Usage
+
+This library provides categorical error types that are designed to be actionable. Each anomaly has a category and a retryable status to help with error handling and recovery strategies.
+
+### Basic Usage
+
+```typescript
+import { 
+  UnavailableAnomaly, 
+  NotFoundAnomaly, 
+  ForbiddenAnomaly,
+  InterruptedAnomaly,
+  FaultAnomaly,
+  isAnomaly
+} from '@tryghost/anomalies';
+
+// Throw specific anomaly types
+throw new UnavailableAnomaly('Database connection failed');
+throw new NotFoundAnomaly('User not found');
+throw new ForbiddenAnomaly('Access denied');
+
+// Override retryable for InterruptedAnomaly and FaultAnomaly
+throw new InterruptedAnomaly('Connection interrupted', true); // Make it retryable
+throw new FaultAnomaly('Service fault', false); // Make it non-retryable
+
+// Check if an error is an anomaly
+try {
+  // some operation
+} catch (error) {
+  if (isAnomaly(error)) {
+    console.log(`Category: ${error.category}`);
+    console.log(`Retryable: ${error.retryable}`);
+  }
+}
+```
+
+### Available Anomaly Types
+
+| Anomaly Class | Category | Retryable |
+|---------------|----------|-----------|
+| `UnavailableAnomaly` | `unavailable` | yes |
+| `BusyAnomaly` | `busy` | yes |
+| `InterruptedAnomaly` | `interrupted` | maybe* |
+| `FaultAnomaly` | `fault` | maybe* |
+| `IncorrectAnomaly` | `incorrect` | no |
+| `ForbiddenAnomaly` | `forbidden` | no |
+| `UnsupportedAnomaly` | `unsupported` | no |
+| `NotFoundAnomaly` | `not-found` | no |
+| `ConflictAnomaly` | `conflict` | no |
+
+*Defaults to false, but can be overridden during construction
+
+### Retryable Status
+
+Each anomaly has a boolean `retryable` property that indicates whether the operation could be retried with a different outcome:
+
+- `true`: Operation should be retried
+- `false`: Operation should not be retried
+
+For `InterruptedAnomaly` and `FaultAnomaly`, you can override the default retryable behavior by passing a boolean as the second parameter to the constructor.
+
+For more information about the approach, see the [Cognitect Labs anomalies library](https://github.com/cognitect-labs/anomalies).
+
+### Error Handling Pattern
+
+```typescript
+import { 
+  UnavailableAnomaly, 
+  NotFoundAnomaly, 
+  ForbiddenAnomaly,
+  BusyAnomaly 
+} from '@tryghost/anomalies';
+
+async function fetchUser(id: string) {
+  try {
+    return await userService.getUser(id);
+  } catch (error) {
+    if (error instanceof NotFoundAnomaly) {
+      // Handle missing user
+      console.log('User not found, creating default user');
+      return createDefaultUser();
+    } else if (error instanceof ForbiddenAnomaly) {
+      // Handle access denied
+      console.error('Access denied for user:', id);
+      throw error; // Re-throw for caller to handle
+    } else if (error instanceof UnavailableAnomaly || error instanceof BusyAnomaly) {
+      // Handle retryable errors
+      console.log('Service unavailable, retrying...');
+      await delay(1000);
+      return fetchUser(id); // Retry
+    } else if (error instanceof InterruptedAnomaly && error.retryable) {
+      // Handle interrupted operation that's marked as retryable
+      console.log('Operation interrupted but retryable, retrying...');
+      await delay(500);
+      return fetchUser(id); // Retry
+    } else {
+      // Handle unexpected errors
+      throw error;
+    }
+  }
+}
+```
+
+
+## Develop
+
+This is a monorepo package.
+
+Follow the instructions for the top-level repo.
+1. `git clone` this repo & `cd` into it as usual
+2. Run `yarn` to install top-level dependencies.
+
+
+
+## Test
+
+- `yarn lint` run just eslint
+- `yarn test` run lint and tests

--- a/packages/anomalies/package.json
+++ b/packages/anomalies/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@tryghost/anomalies",
+  "version": "0.0.0",
+  "repository": "https://github.com/TryGhost/framework/tree/main/packages/anomalies",
+  "author": "Ghost Foundation",
+  "license": "MIT",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
+  "sideEffects": false,
+  "scripts": {
+    "dev": "echo \"Implement me!\"",
+    "build": "yarn build:ts",
+    "build:ts": "tsc",
+    "prepare": "tsc",
+    "test:unit": "NODE_ENV=testing c8 --src src --all --check-coverage --reporter text --reporter cobertura mocha -r ts-node/register './test/**/*.test.ts'",
+    "test": "yarn test:types && yarn test:unit",
+    "test:types": "tsc --noEmit",
+    "lint:code": "eslint src/ --ext .ts --cache",
+    "lint": "yarn lint:code && yarn lint:test",
+    "lint:test": "eslint -c test/.eslintrc.js test/ --ext .ts --cache"
+  },
+  "files": [
+    "build"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "devDependencies": {
+    "c8": "10.1.3",
+    "mocha": "11.7.1",
+    "sinon": "21.0.0",
+    "ts-node": "10.9.2",
+    "typescript": "5.8.3"
+  },
+  "dependencies": {}
+}

--- a/packages/anomalies/src/anomalies.ts
+++ b/packages/anomalies/src/anomalies.ts
@@ -1,0 +1,123 @@
+export type AnomalyCategory =
+  | 'unavailable'
+  | 'interrupted'
+  | 'busy'
+  | 'incorrect'
+  | 'forbidden'
+  | 'unsupported'
+  | 'not-found'
+  | 'conflict'
+  | 'fault';
+
+class Anomaly extends Error {
+    public readonly category: AnomalyCategory;
+    public readonly retryable: boolean;
+
+    constructor(category: AnomalyCategory, message?: string, retryable?: boolean) {
+        const defaultMessage = getDefaultMessage(category);
+        super(message || defaultMessage);
+
+        this.name = 'Anomaly';
+        this.category = category;
+        this.retryable = retryable || getRetryable(category);
+    }
+}
+
+export class UnavailableAnomaly extends Anomaly {
+    constructor(message?: string) {
+        super('unavailable', message);
+    }
+}
+
+export class InterruptedAnomaly extends Anomaly {
+    constructor(message?: string, retryable?: boolean) {
+        super('interrupted', message, retryable);
+    }
+}
+
+export class BusyAnomaly extends Anomaly {
+    constructor(message?: string) {
+        super('busy', message);
+    }
+}
+
+export class IncorrectAnomaly extends Anomaly {
+    constructor(message?: string) {
+        super('incorrect', message);
+    }
+}
+
+export class ForbiddenAnomaly extends Anomaly {
+    constructor(message?: string) {
+        super('forbidden', message);
+    }
+}
+
+export class UnsupportedAnomaly extends Anomaly {
+    constructor(message?: string) {
+        super('unsupported', message);
+    }
+}
+
+export class NotFoundAnomaly extends Anomaly {
+    constructor(message?: string) {
+        super('not-found', message);
+    }
+}
+
+export class ConflictAnomaly extends Anomaly {
+    constructor(message?: string) {
+        super('conflict', message);
+    }
+}
+
+export class FaultAnomaly extends Anomaly {
+    constructor(message?: string, retryable?: boolean) {
+        super('fault', message, retryable);
+    }
+}
+
+function getDefaultMessage(category: AnomalyCategory): string {
+    switch (category) {
+    case 'unavailable':
+        return 'Service is unavailable';
+    case 'interrupted':
+        return 'Operation was interrupted';
+    case 'busy':
+        return 'Service is busy';
+    case 'incorrect':
+        return 'Request is incorrect';
+    case 'forbidden':
+        return 'Access forbidden';
+    case 'unsupported':
+        return 'Operation not supported';
+    case 'not-found':
+        return 'Resource not found';
+    case 'conflict':
+        return 'Request conflicts with current state';
+    case 'fault':
+        return 'Internal service fault';
+    }
+}
+
+function getRetryable(category: AnomalyCategory): boolean {
+    switch (category) {
+    case 'unavailable':
+    case 'busy':
+        return true;
+    case 'interrupted':
+    case 'fault':
+        // "Maybe" results are false by default, but overridable on creation
+        return false;
+    case 'incorrect':
+    case 'forbidden':
+    case 'unsupported':
+    case 'not-found':
+    case 'conflict':
+        return false;
+    }
+}
+
+export function isAnomaly(error: any): error is Anomaly {
+    return error instanceof Anomaly;
+}

--- a/packages/anomalies/src/index.ts
+++ b/packages/anomalies/src/index.ts
@@ -1,0 +1,1 @@
+export * from './anomalies';

--- a/packages/anomalies/test/.eslintrc.js
+++ b/packages/anomalies/test/.eslintrc.js
@@ -1,0 +1,7 @@
+module.exports = {
+    parser: '@typescript-eslint/parser',
+    plugins: ['ghost'],
+    extends: [
+        'plugin:ghost/test'
+    ]
+};

--- a/packages/anomalies/test/anomalies.test.ts
+++ b/packages/anomalies/test/anomalies.test.ts
@@ -1,0 +1,164 @@
+import assert from 'assert/strict';
+import {
+    UnavailableAnomaly,
+    InterruptedAnomaly,
+    BusyAnomaly,
+    IncorrectAnomaly,
+    ForbiddenAnomaly,
+    UnsupportedAnomaly,
+    NotFoundAnomaly,
+    ConflictAnomaly,
+    FaultAnomaly,
+    isAnomaly
+} from '../src/index';
+
+describe('Anomalies', function () {
+    describe('Specific anomaly classes', function () {
+        it('should create UnavailableAnomaly correctly', function () {
+            const anomaly = new UnavailableAnomaly();
+            assert.equal(anomaly.category, 'unavailable');
+            assert.equal(anomaly.message, 'Service is unavailable');
+            assert.equal(anomaly.retryable, true);
+        });
+
+        it('should create InterruptedAnomaly correctly', function () {
+            const anomaly = new InterruptedAnomaly('Custom interrupted message');
+            assert.equal(anomaly.category, 'interrupted');
+            assert.equal(anomaly.message, 'Custom interrupted message');
+            assert.equal(anomaly.retryable, false);
+        });
+
+        it('should create BusyAnomaly correctly', function () {
+            const anomaly = new BusyAnomaly();
+            assert.equal(anomaly.category, 'busy');
+            assert.equal(anomaly.retryable, true);
+        });
+
+        it('should create IncorrectAnomaly correctly', function () {
+            const anomaly = new IncorrectAnomaly();
+            assert.equal(anomaly.category, 'incorrect');
+            assert.equal(anomaly.retryable, false);
+        });
+
+        it('should create ForbiddenAnomaly correctly', function () {
+            const anomaly = new ForbiddenAnomaly();
+            assert.equal(anomaly.category, 'forbidden');
+            assert.equal(anomaly.retryable, false);
+        });
+
+        it('should create UnsupportedAnomaly correctly', function () {
+            const anomaly = new UnsupportedAnomaly();
+            assert.equal(anomaly.category, 'unsupported');
+            assert.equal(anomaly.retryable, false);
+        });
+
+        it('should create NotFoundAnomaly correctly', function () {
+            const anomaly = new NotFoundAnomaly();
+            assert.equal(anomaly.category, 'not-found');
+            assert.equal(anomaly.retryable, false);
+        });
+
+        it('should create ConflictAnomaly correctly', function () {
+            const anomaly = new ConflictAnomaly();
+            assert.equal(anomaly.category, 'conflict');
+            assert.equal(anomaly.retryable, false);
+        });
+
+        it('should create FaultAnomaly correctly', function () {
+            const anomaly = new FaultAnomaly();
+            assert.equal(anomaly.category, 'fault');
+            assert.equal(anomaly.retryable, false);
+        });
+    });
+
+    describe('isAnomaly function', function () {
+        it('should return true for anomaly instances', function () {
+            const anomaly = new UnavailableAnomaly();
+            assert.equal(isAnomaly(anomaly), true);
+        });
+
+        it('should return false for regular errors', function () {
+            const error = new Error('Regular error');
+            assert.equal(isAnomaly(error), false);
+        });
+
+        it('should return false for non-error objects', function () {
+            assert.equal(isAnomaly({}), false);
+            assert.equal(isAnomaly(null), false);
+            assert.equal(isAnomaly(undefined), false);
+        });
+    });
+
+
+    describe('Edge cases', function () {
+        it('should use default messages when no custom message provided', function () {
+            const anomaly = new UnavailableAnomaly();
+            assert.equal(anomaly.message, 'Service is unavailable');
+        });
+
+        it('should test all anomaly types with custom messages', function () {
+            const customMessage = 'Custom test message';
+            const anomalies = [
+                new UnavailableAnomaly(customMessage),
+                new InterruptedAnomaly(customMessage),
+                new BusyAnomaly(customMessage),
+                new IncorrectAnomaly(customMessage),
+                new ForbiddenAnomaly(customMessage),
+                new UnsupportedAnomaly(customMessage),
+                new NotFoundAnomaly(customMessage),
+                new ConflictAnomaly(customMessage),
+                new FaultAnomaly(customMessage)
+            ];
+
+            anomalies.forEach((anomaly) => {
+                assert.equal(anomaly.message, customMessage);
+            });
+        });
+
+        it('should allow overriding retryable for InterruptedAnomaly', function () {
+            const defaultInterrupted = new InterruptedAnomaly();
+            assert.equal(defaultInterrupted.retryable, false);
+
+            const retryableInterrupted = new InterruptedAnomaly('Custom message', true);
+            assert.equal(retryableInterrupted.retryable, true);
+
+            const nonRetryableInterrupted = new InterruptedAnomaly('Custom message', false);
+            assert.equal(nonRetryableInterrupted.retryable, false);
+        });
+
+        it('should allow overriding retryable for FaultAnomaly', function () {
+            const defaultFault = new FaultAnomaly();
+            assert.equal(defaultFault.retryable, false);
+
+            const retryableFault = new FaultAnomaly('Custom message', true);
+            assert.equal(retryableFault.retryable, true);
+
+            const nonRetryableFault = new FaultAnomaly('Custom message', false);
+            assert.equal(nonRetryableFault.retryable, false);
+        });
+
+        it('should not allow overriding retryable for anomalies without retryable parameter', function () {
+            // These should always maintain their default retryable values
+            const unavailable = new UnavailableAnomaly();
+            assert.equal(unavailable.retryable, true);
+
+            const busy = new BusyAnomaly();
+            assert.equal(busy.retryable, true);
+
+            const incorrect = new IncorrectAnomaly();
+            assert.equal(incorrect.retryable, false);
+
+            const forbidden = new ForbiddenAnomaly();
+            assert.equal(forbidden.retryable, false);
+
+            const unsupported = new UnsupportedAnomaly();
+            assert.equal(unsupported.retryable, false);
+
+            const notFound = new NotFoundAnomaly();
+            assert.equal(notFound.retryable, false);
+
+            const conflict = new ConflictAnomaly();
+            assert.equal(conflict.retryable, false);
+        });
+    });
+});

--- a/packages/anomalies/tsconfig.json
+++ b/packages/anomalies/tsconfig.json
@@ -1,0 +1,107 @@
+{
+    "ts-node": {
+        "files": true
+    },
+    "compilerOptions": {
+        /* Visit https://aka.ms/tsconfig to read more about this file */
+        /* Projects */
+        "incremental": true, /* Save .tsbuildinfo files to allow for incremental compilation of projects. */
+        // "composite": true,                                /* Enable constraints that allow a TypeScript project to be used with project references. */
+        // "tsBuildInfoFile": "./.tsbuildinfo",              /* Specify the path to .tsbuildinfo incremental compilation file. */
+        // "disableSourceOfProjectReferenceRedirect": true,  /* Disable preferring source files instead of declaration files when referencing composite projects. */
+        // "disableSolutionSearching": true,                 /* Opt a project out of multi-project reference checking when editing. */
+        // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
+        /* Language and Environment */
+        "target": "es2022", /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
+        // "lib": ["es2019"],                                      /* Specify a set of bundled library declaration files that describe the target runtime environment. */
+        // "jsx": "preserve",                                /* Specify what JSX code is generated. */
+        // "experimentalDecorators": true,                   /* Enable experimental support for legacy experimental decorators. */
+        // "emitDecoratorMetadata": true,                    /* Emit design-type metadata for decorated declarations in source files. */
+        // "jsxFactory": "",                                 /* Specify the JSX factory function used when targeting React JSX emit, e.g. 'React.createElement' or 'h'. */
+        // "jsxFragmentFactory": "",                         /* Specify the JSX Fragment reference used for fragments when targeting React JSX emit e.g. 'React.Fragment' or 'Fragment'. */
+        // "jsxImportSource": "",                            /* Specify module specifier used to import the JSX factory functions when using 'jsx: react-jsx*'. */
+        // "reactNamespace": "",                             /* Specify the object invoked for 'createElement'. This only applies when targeting 'react' JSX emit. */
+        // "noLib": true,                                    /* Disable including any library files, including the default lib.d.ts. */
+        // "useDefineForClassFields": true,                  /* Emit ECMAScript-standard-compliant class fields. */
+        // "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
+        /* Modules */
+        "module": "commonjs", /* Specify what module code is generated. */
+        "rootDir": "src", /* Specify the root folder within your source files. */
+        // "moduleResolution": "node10",                     /* Specify how TypeScript looks up a file from a given module specifier. */
+        // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
+        // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
+        // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
+        // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */
+        // "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */
+        // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
+        // "moduleSuffixes": [],                             /* List of file name suffixes to search when resolving a module. */
+        // "allowImportingTsExtensions": true,               /* Allow imports to include TypeScript file extensions. Requires '--moduleResolution bundler' and either '--noEmit' or '--emitDeclarationOnly' to be set. */
+        // "resolvePackageJsonExports": true,                /* Use the package.json 'exports' field when resolving package imports. */
+        // "resolvePackageJsonImports": true,                /* Use the package.json 'imports' field when resolving imports. */
+        // "customConditions": [],                           /* Conditions to set in addition to the resolver-specific defaults when resolving imports. */
+        "resolveJsonModule": true, /* Enable importing .json files. */
+        // "allowArbitraryExtensions": true,                 /* Enable importing files with any extension, provided a declaration file is present. */
+        // "noResolve": true,                                /* Disallow 'import's, 'require's or '<reference>'s from expanding the number of files TypeScript should add to a project. */
+        /* JavaScript Support */
+        // "allowJs": true,                                  /* Allow JavaScript files to be a part of your program. Use the 'checkJS' option to get errors from these files. */
+        // "checkJs": true,                                  /* Enable error reporting in type-checked JavaScript files. */
+        // "maxNodeModuleJsDepth": 1,                        /* Specify the maximum folder depth used for checking JavaScript files from 'node_modules'. Only applicable with 'allowJs'. */
+        /* Emit */
+        "declaration": true, /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
+        // "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
+        // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
+        // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
+        // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
+        // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
+        "outDir": "build", /* Specify an output folder for all emitted files. */
+        // "removeComments": true,                           /* Disable emitting comments. */
+        // "noEmit": true,                                   /* Disable emitting files from a compilation. */
+        // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */
+        // "importsNotUsedAsValues": "remove",               /* Specify emit/checking behavior for imports that are only used for types. */
+        // "downlevelIteration": true,                       /* Emit more compliant, but verbose and less performant JavaScript for iteration. */
+        // "sourceRoot": "",                                 /* Specify the root path for debuggers to find the reference source code. */
+        // "mapRoot": "",                                    /* Specify the location where debugger should locate map files instead of generated locations. */
+        // "inlineSources": true,                            /* Include source code in the sourcemaps inside the emitted JavaScript. */
+        // "emitBOM": true,                                  /* Emit a UTF-8 Byte Order Mark (BOM) in the beginning of output files. */
+        // "newLine": "crlf",                                /* Set the newline character for emitting files. */
+        // "stripInternal": true,                            /* Disable emitting declarations that have '@internal' in their JSDoc comments. */
+        // "noEmitHelpers": true,                            /* Disable generating custom helper functions like '__extends' in compiled output. */
+        // "noEmitOnError": true,                            /* Disable emitting files if any type checking errors are reported. */
+        // "preserveConstEnums": true,                       /* Disable erasing 'const enum' declarations in generated code. */
+        // "declarationDir": "./",                           /* Specify the output directory for generated declaration files. */
+        // "preserveValueImports": true,                     /* Preserve unused imported values in the JavaScript output that would otherwise be removed. */
+        /* Interop Constraints */
+        // "isolatedModules": true,                          /* Ensure that each file can be safely transpiled without relying on other imports. */
+        // "verbatimModuleSyntax": true,                     /* Do not transform or elide any imports or exports not marked as type-only, ensuring they are written in the output file's format based on the 'module' setting. */
+        // "allowSyntheticDefaultImports": true,             /* Allow 'import x from y' when a module doesn't have a default export. */
+        "esModuleInterop": true, /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */
+        // "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */
+        "forceConsistentCasingInFileNames": true, /* Ensure that casing is correct in imports. */
+        /* Type Checking */
+        "strict": true, /* Enable all strict type-checking options. */
+        "noImplicitAny": true, /* Enable error reporting for expressions and declarations with an implied 'any' type. */
+        // "strictNullChecks": true,                         /* When type checking, take into account 'null' and 'undefined'. */
+        // "strictFunctionTypes": true,                      /* When assigning functions, check to ensure parameters and the return values are subtype-compatible. */
+        // "strictBindCallApply": true,                      /* Check that the arguments for 'bind', 'call', and 'apply' methods match the original function. */
+        // "strictPropertyInitialization": true,             /* Check for class properties that are declared but not set in the constructor. */
+        // "noImplicitThis": true,                           /* Enable error reporting when 'this' is given the type 'any'. */
+        // "useUnknownInCatchVariables": true,               /* Default catch clause variables as 'unknown' instead of 'any'. */
+        // "alwaysStrict": true,                             /* Ensure 'use strict' is always emitted. */
+        // "noUnusedLocals": true,                           /* Enable error reporting when local variables aren't read. */
+        // "noUnusedParameters": true,                       /* Raise an error when a function parameter isn't read. */
+        // "exactOptionalPropertyTypes": true,               /* Interpret optional property types as written, rather than adding 'undefined'. */
+        // "noImplicitReturns": true,                        /* Enable error reporting for codepaths that do not explicitly return in a function. */
+        // "noFallthroughCasesInSwitch": true,               /* Enable error reporting for fallthrough cases in switch statements. */
+        // "noUncheckedIndexedAccess": true,                 /* Add 'undefined' to a type when accessed using an index. */
+        // "noImplicitOverride": true,                       /* Ensure overriding members in derived classes are marked with an override modifier. */
+        // "noPropertyAccessFromIndexSignature": true,       /* Enforces using indexed accessors for keys declared using an indexed type. */
+        // "allowUnusedLabels": true,                        /* Disable error reporting for unused labels. */
+        // "allowUnreachableCode": true,                     /* Disable error reporting for unreachable code. */
+        /* Completeness */
+        // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
+        "skipLibCheck": true /* Skip type checking all .d.ts files. */
+    },
+    "include": [
+        "src/**/*"
+    ]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3806,6 +3806,13 @@ chokidar@^3.5.3:
   optionalDependencies:
     fsevents "~2.3.2"
 
+chokidar@^4.0.1:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-4.0.3.tgz#7be37a4c03c9aee1ecfe862a4a23b2c70c205d30"
+  integrity sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==
+  dependencies:
+    readdirp "^4.0.1"
+
 chownr@^1.1.1:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.4.tgz#6fc9d7b42d32a583596337666e7d08084da2cc6b"
@@ -5536,7 +5543,7 @@ glob-parent@^6.0.2:
   dependencies:
     is-glob "^4.0.3"
 
-glob@^10.4.1:
+glob@^10.4.1, glob@^10.4.5:
   version "10.4.5"
   resolved "https://registry.yarnpkg.com/glob/-/glob-10.4.5.tgz#f4d9f0b90ffdbab09c9d77f5f29b4262517b0956"
   integrity sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==
@@ -7158,7 +7165,7 @@ minimatch@^5.0.1, minimatch@^5.1.0, minimatch@^5.1.6, minimatch@~5.1.2:
   dependencies:
     brace-expansion "^2.0.1"
 
-minimatch@^9.0.4:
+minimatch@^9.0.4, minimatch@^9.0.5:
   version "9.0.5"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-9.0.5.tgz#d74f9dd6b57d83d8e98cfb82133b03978bc929e5"
   integrity sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==
@@ -7306,6 +7313,32 @@ mocha@10.8.2:
     workerpool "^6.5.1"
     yargs "^16.2.0"
     yargs-parser "^20.2.9"
+    yargs-unparser "^2.0.0"
+
+mocha@11.7.1:
+  version "11.7.1"
+  resolved "https://registry.yarnpkg.com/mocha/-/mocha-11.7.1.tgz#91948fecd624fb4bd154ed260b7e1ad3910d7c7a"
+  integrity sha512-5EK+Cty6KheMS/YLPPMJC64g5V61gIR25KsRItHw6x4hEKT6Njp1n9LOlH4gpevuwMVS66SXaBBpg+RWZkza4A==
+  dependencies:
+    browser-stdout "^1.3.1"
+    chokidar "^4.0.1"
+    debug "^4.3.5"
+    diff "^7.0.0"
+    escape-string-regexp "^4.0.0"
+    find-up "^5.0.0"
+    glob "^10.4.5"
+    he "^1.2.0"
+    js-yaml "^4.1.0"
+    log-symbols "^4.1.0"
+    minimatch "^9.0.5"
+    ms "^2.1.3"
+    picocolors "^1.1.1"
+    serialize-javascript "^6.0.2"
+    strip-json-comments "^3.1.1"
+    supports-color "^8.1.1"
+    workerpool "^9.2.0"
+    yargs "^17.7.2"
+    yargs-parser "^21.1.1"
     yargs-unparser "^2.0.0"
 
 moment-timezone@^0.5.23, moment-timezone@^0.5.33:
@@ -8177,6 +8210,11 @@ readdir-glob@^1.1.2:
   dependencies:
     minimatch "^5.1.0"
 
+readdirp@^4.0.1:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-4.1.2.tgz#eb85801435fbf2a7ee58f19e0921b068fc69948d"
+  integrity sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==
+
 readdirp@~3.6.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-3.6.0.tgz#74a370bd857116e245b29cc97340cd431a02a6c7"
@@ -8722,6 +8760,17 @@ sinon@19.0.5:
     "@sinonjs/samsam" "^8.0.1"
     diff "^7.0.0"
     nise "^6.1.1"
+    supports-color "^7.2.0"
+
+sinon@21.0.0:
+  version "21.0.0"
+  resolved "https://registry.yarnpkg.com/sinon/-/sinon-21.0.0.tgz#dbda73abc7e6cb803fef3368cfbecbb5936e8a9e"
+  integrity sha512-TOgRcwFPbfGtpqvZw+hyqJDvqfapr1qUlOizROIk4bBLjlsjlB00Pg6wMFXNtJRpu+eCZuVOaLatG7M8105kAw==
+  dependencies:
+    "@sinonjs/commons" "^3.0.1"
+    "@sinonjs/fake-timers" "^13.0.5"
+    "@sinonjs/samsam" "^8.0.1"
+    diff "^7.0.0"
     supports-color "^7.2.0"
 
 slash@^3.0.0:
@@ -9702,7 +9751,7 @@ word-wrap@^1.2.5, word-wrap@~1.2.3:
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.5.tgz#d2c45c6dd4fbce621a66f136cbe328afd0410b34"
   integrity sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==
 
-workerpool@9.3.3:
+workerpool@9.3.3, workerpool@^9.2.0:
   version "9.3.3"
   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-9.3.3.tgz#e75281fe62e851afb21cdeef8fa85f6a62ec3583"
   integrity sha512-slxCaKbYjEdFT/o2rH9xS1hf4uRDch1w7Uo+apxhZ+sf/1d9e0ZVkn42kPNGP2dgjIx6YFvSevj0zHvbWe2jdw==


### PR DESCRIPTION
Based on the anomalies package by Cognitect Labs, this TypeScript version is designed to be simple to use and provide a great deal of context simply by the error type.

The categories are generic enough to cover all errors, but can also map nicely to HTTP errors.

The semantics of the errors include whether or not they are retry-able, based on the category rather than being left up to the callee to decide for each error.