### PR TITLE
Switched to "safe" version in default request user-agent header

### DIFF
--- a/packages/request/lib/request.js
+++ b/packages/request/lib/request.js
@@ -11,7 +11,7 @@ let cacheableLookup;
 
 const defaultOptions = {
     headers: {
-        'user-agent': 'Ghost/' + ghostVersion.original + ' (https://github.com/TryGhost/Ghost)'
+        'user-agent': 'Ghost/' + ghostVersion.safe + ' (https://github.com/TryGhost/Ghost)'
     },
     method: 'GET'
 };

--- a/packages/request/test/request.test.js
+++ b/packages/request/test/request.test.js
@@ -7,6 +7,18 @@ const nock = require('nock');
 const request = require('../lib/request');
 
 describe('Request', function () {
+    it('has "safe" version in default user-agent header', function () {
+        const url = 'http://some-website.com/endpoint/';
+
+        nock('http://some-website.com')
+            .get('/endpoint/')
+            .reply(200, 'Response body');
+
+        return request(url, {}).then(function ({req}) {
+            req.headers['user-agent'].should.match(/Ghost\/[0-9]+\.[0-9]+\s/);
+        });
+    });
+
     it('[success] should return response for http request', function () {
         const url = 'http://some-website.com/endpoint/';
         const expectedResponse = {


### PR DESCRIPTION
no issue

- we don't usually want to expose the full patch version of software, instead limiting to the `major.minor` part
- switched from `ghostVersion.original` to `ghostVersion.safe` in the default user-agent to limit the exposed data
