### PR TITLE
Fixed smart count false positive on subquery JOINs

### DIFF
--- a/packages/bookshelf-pagination/lib/bookshelf-pagination.js
+++ b/packages/bookshelf-pagination/lib/bookshelf-pagination.js
@@ -68,6 +68,7 @@ defaults = {
  * @api private
  */
 paginationUtils = {
+    hasMultiTableSource: hasMultiTableSource,
     /**
      * ### Parse Options
      * Take the given options and ensure they are valid pagination options, else use the defaults

--- a/packages/bookshelf-pagination/lib/bookshelf-pagination.js
+++ b/packages/bookshelf-pagination/lib/bookshelf-pagination.js
@@ -14,47 +14,40 @@ const messages = {
 let defaults;
 let paginationUtils;
 
-const JOIN_KEYWORD_REGEX = /\bjoin\b/i;
-const FROM_CLAUSE_REGEX =
-    /\bfrom\b([\s\S]*?)(?:\bwhere\b|\bgroup\s+by\b|\border\s+by\b|\blimit\b|\boffset\b|$)/i;
-
-function getCompiledSql(queryBuilder) {
-    const compiledQuery = queryBuilder.toSQL();
-
-    if (Array.isArray(compiledQuery)) {
-        return compiledQuery
-            .map((query) => {
-                return query && query.sql ? query.sql : '';
-            })
-            .join(' ');
+// Smart count only uses count(*) for single-table queries. Multi-table shapes
+// — outer JOINs, UNIONs, derived/raw FROM sources, or comma-separated FROM
+// lists — can duplicate base rows, so fetchPage must use count(distinct id).
+//
+// Crucially, JOINs that appear inside a subquery (eg. `where id in (select ...
+// inner join ...)`) do NOT count — the outer row set is still unique per base
+// row, so count(*) is both safe and materially faster. Walking knex's AST
+// instead of the compiled SQL gives us exactly this scoping for free.
+function hasMultiTableSource(queryBuilder) {
+    for (const statement of queryBuilder._statements) {
+        // Any outer join duplicates the base row set.
+        if (statement.grouping === 'join') {
+            return true;
+        }
+        // UNION combines multiple SELECTs — the outer row set comes
+        // from more than one source, so count(*) is unsafe.
+        if (statement.grouping === 'union') {
+            return true;
+        }
     }
 
-    return compiledQuery && compiledQuery.sql ? compiledQuery.sql : '';
-}
+    // For a bookshelf Model the outer FROM is normally a plain table name
+    // string. Anything else — a QueryBuilder (derived table) or a Raw (eg.
+    // `fromRaw('a, b')`) — can carry duplicate-producing shape that we can't
+    // introspect further, so treat it as multi-source.
+    const table = queryBuilder._single.table;
+    if (table && typeof table !== 'string') {
+        return true;
+    }
+    if (typeof table === 'string' && table.includes(',')) {
+        return true;
+    }
 
-function extractFromClause(sql) {
-    const fromClauseMatch = sql.match(FROM_CLAUSE_REGEX);
-
-    return fromClauseMatch ? fromClauseMatch[1] : '';
-}
-
-function hasJoinKeyword(sql) {
-    return JOIN_KEYWORD_REGEX.test(sql);
-}
-
-function hasCommaSeparatedFromSources(sql) {
-    return extractFromClause(sql).includes(',');
-}
-
-// Smart count only uses count(*) for single-table queries.
-// This check flags multi-table sources in two forms:
-// 1) explicit JOIN keywords (join, left join, join raw, etc.)
-// 2) old-style comma-separated FROM lists (eg `from posts, tags`)
-// Both can duplicate base rows, so fetchPage should use count(distinct id).
-function hasMultiTableSource(queryBuilder) {
-    const sql = getCompiledSql(queryBuilder);
-
-    return hasJoinKeyword(sql) || hasCommaSeparatedFromSources(sql);
+    return false;
 }
 
 /**

--- a/packages/bookshelf-pagination/package.json
+++ b/packages/bookshelf-pagination/package.json
@@ -28,6 +28,9 @@
     "lodash": "4.18.1"
   },
   "devDependencies": {
-    "sinon": "catalog:"
+    "bookshelf": "1.2.0",
+    "knex": "3.2.9",
+    "sinon": "catalog:",
+    "sqlite3": "5.1.7"
   }
 }

--- a/packages/bookshelf-pagination/test/pagination-integration.test.js
+++ b/packages/bookshelf-pagination/test/pagination-integration.test.js
@@ -1,0 +1,283 @@
+// End-to-end tests for the pagination plugin against a real bookshelf model
+// backed by an in-memory sqlite database. These pin the plugin's assumptions
+// about knex's query-builder AST (`_statements`, `_single.table`) to the
+// versions of knex and bookshelf actually installed, and validate that the
+// chosen count aggregate returns the same row count as the matching fetch.
+const assert = require('node:assert/strict');
+const knex = require('knex');
+const bookshelf = require('bookshelf');
+const paginationPlugin = require('../lib/bookshelf-pagination');
+
+const {hasMultiTableSource} = paginationPlugin.paginationUtils;
+
+async function setupDatabase() {
+    const db = knex({
+        client: 'sqlite3',
+        useNullAsDefault: true,
+        connection: ':memory:'
+    });
+
+    await db.schema.createTable('authors', (t) => {
+        t.string('id').primary();
+        t.string('name');
+    });
+    await db.schema.createTable('posts', (t) => {
+        t.string('id').primary();
+        t.string('title');
+        t.string('status');
+        t.string('author_id');
+    });
+    await db.schema.createTable('tags', (t) => {
+        t.string('id').primary();
+        t.string('name');
+    });
+    await db.schema.createTable('posts_tags', (t) => {
+        t.string('post_id');
+        t.string('tag_id');
+    });
+
+    await db('authors').insert([
+        {id: 'a1', name: 'Alice'},
+        {id: 'a2', name: 'Bob'}
+    ]);
+    await db('posts').insert([
+        {id: 'p1', title: 'one', status: 'published', author_id: 'a1'},
+        {id: 'p2', title: 'two', status: 'published', author_id: 'a1'},
+        {id: 'p3', title: 'three', status: 'draft', author_id: 'a2'}
+    ]);
+    await db('tags').insert([
+        {id: 't1', name: 'tech'},
+        {id: 't2', name: 'news'}
+    ]);
+    // p1 has two tags — the outer-join cases below will duplicate p1 into
+    // two physical rows, which is what makes count(*) vs count(distinct)
+    // observable at the result level.
+    await db('posts_tags').insert([
+        {post_id: 'p1', tag_id: 't1'},
+        {post_id: 'p1', tag_id: 't2'},
+        {post_id: 'p2', tag_id: 't1'}
+    ]);
+
+    // Capture every compiled SQL query so each test can assert which count
+    // aggregate the plugin chose by inspecting the count query directly.
+    const queries = [];
+    db.on('query', (q) => {
+        queries.push(q.sql);
+    });
+
+    const bk = bookshelf(db);
+    paginationPlugin(bk);
+
+    const Post = bk.model('Post', {tableName: 'posts', idAttribute: 'id'});
+
+    return {db, Post, queries};
+}
+
+function countQuerySql(queries) {
+    return queries.find(sql => typeof sql === 'string' && /\bcount\(/i.test(sql));
+}
+
+describe('hasMultiTableSource against real knex builders', function () {
+    // These exercise hasMultiTableSource directly using real knex
+    // QueryBuilders (no DB connection). They pin the plugin's assumptions
+    // about knex's internal AST shape — `_statements` / `_single.table` —
+    // to the version of knex installed, and cover branches that are hard
+    // to drive end-to-end through fetchPage.
+    let db;
+
+    beforeEach(function () {
+        db = knex({client: 'sqlite3', useNullAsDefault: true});
+    });
+
+    afterEach(async function () {
+        await db.destroy();
+    });
+
+    it('returns false for a plain single-table query', function () {
+        assert.equal(hasMultiTableSource(db('posts').where('status', 'published')), false);
+    });
+
+    it('returns false when a JOIN is nested inside a WHERE subquery', function () {
+        const qb = db('posts').whereIn('posts.id', function () {
+            this.select('post_id')
+                .from('posts_tags')
+                .innerJoin('users', 'users.id', 'posts_tags.author_id')
+                .where('users.id', 1);
+        });
+        assert.equal(hasMultiTableSource(qb), false);
+    });
+
+    it('returns true for an outer innerJoin', function () {
+        assert.equal(hasMultiTableSource(db('posts').innerJoin('tags', 'tags.id', 'posts.id')), true);
+    });
+
+    it('returns true for leftJoin, rightJoin and joinRaw', function () {
+        assert.equal(hasMultiTableSource(db('posts').leftJoin('tags', 'tags.id', 'posts.id')), true);
+        assert.equal(hasMultiTableSource(db('posts').joinRaw('right join tags on tags.id = posts.id')), true);
+    });
+
+    it('returns true for a UNION query', function () {
+        const qb = db('posts').select('id').where('status', 'published').union(function () {
+            this.select('id').from('posts').where('status', 'draft');
+        });
+        assert.equal(hasMultiTableSource(qb), true);
+    });
+
+    it('returns true for a derived table in FROM', function () {
+        const derived = db('posts').where('status', 'published').as('sub');
+        assert.equal(hasMultiTableSource(db.queryBuilder().from(derived)), true);
+    });
+
+    it('returns true for fromRaw with multiple tables', function () {
+        assert.equal(hasMultiTableSource(db.queryBuilder().fromRaw('`posts`, `tags`')), true);
+    });
+
+    it('returns true when the table string itself contains a comma', function () {
+        // Real knex accepts this shape; it only fails at execution time.
+        // The detection must still classify it as multi-source.
+        assert.equal(hasMultiTableSource(db('posts, tags')), true);
+    });
+
+    it('returns false for a CTE-only query with a single-table outer FROM', function () {
+        const qb = db('posts')
+            .with('published_ids', db('posts').select('id').where('status', 'published'))
+            .whereIn('posts.id', db('published_ids').select('id'));
+        assert.equal(hasMultiTableSource(qb), false);
+    });
+});
+
+function usesCountStar(sql) {
+    return /\bcount\(\*\) as aggregate\b/i.test(sql);
+}
+
+function usesCountDistinct(sql) {
+    return /\bcount\(distinct posts\.id\) as aggregate\b/i.test(sql);
+}
+
+describe('@tryghost/bookshelf-pagination (integration)', function () {
+    let db;
+    let Post;
+    let queries;
+
+    beforeEach(async function () {
+        ({db, Post, queries} = await setupDatabase());
+    });
+
+    afterEach(async function () {
+        if (db) {
+            await db.destroy();
+        }
+    });
+
+    it('useSmartCount picks count(*) for a plain single-table filter', async function () {
+        const result = await Post.forge()
+            .where('author_id', 'a1')
+            .fetchPage({page: 1, limit: 10, useSmartCount: true});
+
+        const countSql = countQuerySql(queries);
+        assert.ok(usesCountStar(countSql), `expected count(*), got: ${countSql}`);
+        assert.equal(result.pagination.total, 2);
+        assert.equal(result.collection.length, 2);
+    });
+
+    it('useSmartCount picks count(*) when a JOIN is nested inside a WHERE subquery', async function () {
+        // Regression: `where id in (select … inner join …)` must stay on
+        // the count(*) path because the outer query is still single-table.
+        const result = await Post.forge()
+            .query(function (qb) {
+                qb.whereIn('posts.id', function () {
+                    this.select('posts_tags.post_id')
+                        .from('posts_tags')
+                        .innerJoin('posts as p2', 'p2.id', 'posts_tags.post_id')
+                        .innerJoin('authors', 'authors.id', 'p2.author_id')
+                        .where('authors.name', 'Alice');
+                });
+            })
+            .fetchPage({page: 1, limit: 10, useSmartCount: true});
+
+        const countSql = countQuerySql(queries);
+        assert.ok(usesCountStar(countSql), `expected count(*), got: ${countSql}`);
+        assert.equal(result.pagination.total, 2);
+        assert.equal(result.collection.length, 2);
+    });
+
+    it('useSmartCount picks count(distinct) when an outer INNER JOIN duplicates rows', async function () {
+        // p1 has two tags, so posts × posts_tags produces three physical
+        // rows for the two published posts. count(*) would report 3;
+        // count(distinct posts.id) must report 2.
+        const result = await Post.forge()
+            .query(function (qb) {
+                qb.innerJoin('posts_tags', 'posts_tags.post_id', 'posts.id')
+                    .where('posts.status', 'published');
+            })
+            .fetchPage({page: 1, limit: 10, useSmartCount: true});
+
+        const countSql = countQuerySql(queries);
+        assert.ok(usesCountDistinct(countSql), `expected count(distinct), got: ${countSql}`);
+        assert.equal(result.pagination.total, 2);
+    });
+
+    it('useSmartCount picks count(distinct) for a joinRaw', async function () {
+        const result = await Post.forge()
+            .query(function (qb) {
+                qb.joinRaw('inner join `posts_tags` on `posts_tags`.`post_id` = `posts`.`id`')
+                    .where('posts.status', 'published');
+            })
+            .fetchPage({page: 1, limit: 10, useSmartCount: true});
+
+        const countSql = countQuerySql(queries);
+        assert.ok(usesCountDistinct(countSql), `expected count(distinct), got: ${countSql}`);
+        assert.equal(result.pagination.total, 2);
+    });
+
+    it('useSmartCount picks count(distinct) when the FROM source is a derived table', async function () {
+        const result = await Post.forge()
+            .query(function (qb) {
+                qb.from(db('posts').where('status', 'published').as('posts'));
+            })
+            .fetchPage({page: 1, limit: 10, useSmartCount: true});
+
+        const countSql = countQuerySql(queries);
+        assert.ok(usesCountDistinct(countSql), `expected count(distinct), got: ${countSql}`);
+        assert.equal(result.pagination.total, 2);
+    });
+
+    it('useSmartCount picks count(*) when the query has only a CTE (with) clause', async function () {
+        const result = await Post.forge()
+            .query(function (qb) {
+                qb.with('published_ids', db('posts').select('id').where('status', 'published'))
+                    .whereIn('posts.id', db('published_ids').select('id'));
+            })
+            .fetchPage({page: 1, limit: 10, useSmartCount: true});
+
+        const countSql = countQuerySql(queries);
+        assert.ok(usesCountStar(countSql), `expected count(*), got: ${countSql}`);
+        assert.equal(result.pagination.total, 2);
+    });
+
+    it('useBasicCount skips the smart-count check entirely', async function () {
+        // useBasicCount forces count(*) even on a join — the caller opts
+        // in to "I know what I'm doing" and accepts row duplication.
+        // p1 has two tags, so count(*) reports 3 rows for 2 published posts.
+        const result = await Post.forge()
+            .query(function (qb) {
+                qb.innerJoin('posts_tags', 'posts_tags.post_id', 'posts.id')
+                    .where('posts.status', 'published');
+            })
+            .fetchPage({page: 1, limit: 10, useBasicCount: true});
+
+        const countSql = countQuerySql(queries);
+        assert.ok(usesCountStar(countSql), `expected count(*), got: ${countSql}`);
+        assert.equal(result.pagination.total, 3);
+    });
+
+    it('default (no count option) uses count(distinct)', async function () {
+        const result = await Post.forge()
+            .where('status', 'published')
+            .fetchPage({page: 1, limit: 10});
+
+        const countSql = countQuerySql(queries);
+        assert.ok(usesCountDistinct(countSql), `expected count(distinct), got: ${countSql}`);
+        assert.equal(result.pagination.total, 2);
+    });
+});

--- a/packages/bookshelf-pagination/test/pagination-integration.test.js
+++ b/packages/bookshelf-pagination/test/pagination-integration.test.js
@@ -154,7 +154,12 @@ function usesCountDistinct(sql) {
     return /\bcount\(distinct posts\.id\) as aggregate\b/i.test(sql);
 }
 
-describe('@tryghost/bookshelf-pagination (integration)', function () {
+describe('fetchPage end-to-end against real bookshelf + sqlite', function () {
+    // These two tests are the only fetchPage scenarios where the choice of
+    // count aggregate actually changes the returned total (inner-join row
+    // duplication) or is the named regression the PR is about (subquery
+    // JOIN in WHERE). The remaining query shapes are covered by the direct
+    // `hasMultiTableSource` suite above, which is faster and more exhaustive.
     let db;
     let Post;
     let queries;
@@ -169,20 +174,23 @@ describe('@tryghost/bookshelf-pagination (integration)', function () {
         }
     });
 
-    it('useSmartCount picks count(*) for a plain single-table filter', async function () {
+    it('inner join that duplicates rows picks count(distinct) and returns the distinct total', async function () {
+        // p1 has two tags, so posts × posts_tags produces three physical
+        // rows for the two published posts. count(*) would report 3;
+        // count(distinct posts.id) must report 2.
         const result = await Post.forge()
-            .where('author_id', 'a1')
+            .query(function (qb) {
+                qb.innerJoin('posts_tags', 'posts_tags.post_id', 'posts.id')
+                    .where('posts.status', 'published');
+            })
             .fetchPage({page: 1, limit: 10, useSmartCount: true});
 
         const countSql = countQuerySql(queries);
-        assert.ok(usesCountStar(countSql), `expected count(*), got: ${countSql}`);
+        assert.ok(usesCountDistinct(countSql), `expected count(distinct), got: ${countSql}`);
         assert.equal(result.pagination.total, 2);
-        assert.equal(result.collection.length, 2);
     });
 
-    it('useSmartCount picks count(*) when a JOIN is nested inside a WHERE subquery', async function () {
-        // Regression: `where id in (select … inner join …)` must stay on
-        // the count(*) path because the outer query is still single-table.
+    it('subquery JOIN in WHERE picks count(*) — the Ghost regression this PR fixes', async function () {
         const result = await Post.forge()
             .query(function (qb) {
                 qb.whereIn('posts.id', function () {
@@ -199,85 +207,5 @@ describe('@tryghost/bookshelf-pagination (integration)', function () {
         assert.ok(usesCountStar(countSql), `expected count(*), got: ${countSql}`);
         assert.equal(result.pagination.total, 2);
         assert.equal(result.collection.length, 2);
-    });
-
-    it('useSmartCount picks count(distinct) when an outer INNER JOIN duplicates rows', async function () {
-        // p1 has two tags, so posts × posts_tags produces three physical
-        // rows for the two published posts. count(*) would report 3;
-        // count(distinct posts.id) must report 2.
-        const result = await Post.forge()
-            .query(function (qb) {
-                qb.innerJoin('posts_tags', 'posts_tags.post_id', 'posts.id')
-                    .where('posts.status', 'published');
-            })
-            .fetchPage({page: 1, limit: 10, useSmartCount: true});
-
-        const countSql = countQuerySql(queries);
-        assert.ok(usesCountDistinct(countSql), `expected count(distinct), got: ${countSql}`);
-        assert.equal(result.pagination.total, 2);
-    });
-
-    it('useSmartCount picks count(distinct) for a joinRaw', async function () {
-        const result = await Post.forge()
-            .query(function (qb) {
-                qb.joinRaw('inner join `posts_tags` on `posts_tags`.`post_id` = `posts`.`id`')
-                    .where('posts.status', 'published');
-            })
-            .fetchPage({page: 1, limit: 10, useSmartCount: true});
-
-        const countSql = countQuerySql(queries);
-        assert.ok(usesCountDistinct(countSql), `expected count(distinct), got: ${countSql}`);
-        assert.equal(result.pagination.total, 2);
-    });
-
-    it('useSmartCount picks count(distinct) when the FROM source is a derived table', async function () {
-        const result = await Post.forge()
-            .query(function (qb) {
-                qb.from(db('posts').where('status', 'published').as('posts'));
-            })
-            .fetchPage({page: 1, limit: 10, useSmartCount: true});
-
-        const countSql = countQuerySql(queries);
-        assert.ok(usesCountDistinct(countSql), `expected count(distinct), got: ${countSql}`);
-        assert.equal(result.pagination.total, 2);
-    });
-
-    it('useSmartCount picks count(*) when the query has only a CTE (with) clause', async function () {
-        const result = await Post.forge()
-            .query(function (qb) {
-                qb.with('published_ids', db('posts').select('id').where('status', 'published'))
-                    .whereIn('posts.id', db('published_ids').select('id'));
-            })
-            .fetchPage({page: 1, limit: 10, useSmartCount: true});
-
-        const countSql = countQuerySql(queries);
-        assert.ok(usesCountStar(countSql), `expected count(*), got: ${countSql}`);
-        assert.equal(result.pagination.total, 2);
-    });
-
-    it('useBasicCount skips the smart-count check entirely', async function () {
-        // useBasicCount forces count(*) even on a join — the caller opts
-        // in to "I know what I'm doing" and accepts row duplication.
-        // p1 has two tags, so count(*) reports 3 rows for 2 published posts.
-        const result = await Post.forge()
-            .query(function (qb) {
-                qb.innerJoin('posts_tags', 'posts_tags.post_id', 'posts.id')
-                    .where('posts.status', 'published');
-            })
-            .fetchPage({page: 1, limit: 10, useBasicCount: true});
-
-        const countSql = countQuerySql(queries);
-        assert.ok(usesCountStar(countSql), `expected count(*), got: ${countSql}`);
-        assert.equal(result.pagination.total, 3);
-    });
-
-    it('default (no count option) uses count(distinct)', async function () {
-        const result = await Post.forge()
-            .where('status', 'published')
-            .fetchPage({page: 1, limit: 10});
-
-        const countSql = countQuerySql(queries);
-        assert.ok(usesCountDistinct(countSql), `expected count(distinct), got: ${countSql}`);
-        assert.equal(result.pagination.total, 2);
     });
 });

--- a/packages/bookshelf-pagination/test/pagination.test.js
+++ b/packages/bookshelf-pagination/test/pagination.test.js
@@ -77,25 +77,6 @@ function createBookshelf({ countRows, fetchResult, selectError, fetchError } = {
     return { bookshelf, modelState };
 }
 
-// Install `state` onto the fake query builder returned by `model.query()`
-// so that countQuery._statements / _single reflect the scenario under test.
-// Only the keys present on `state` are written.
-function stubCountQuery(model, state) {
-    const originalQuery = model.query;
-    model.query = function () {
-        const qb = originalQuery.apply(this, arguments);
-        if (arguments.length === 0) {
-            if (state.statements !== undefined) {
-                qb._statements = state.statements;
-            }
-            if (state.single !== undefined) {
-                qb._single = state.single;
-            }
-        }
-        return qb;
-    };
-}
-
 describe('@tryghost/bookshelf-pagination', function () {
     it('internal parseOptions handles bad and all limits', function () {
         assert.deepEqual(
@@ -214,8 +195,8 @@ describe('@tryghost/bookshelf-pagination', function () {
         });
     });
 
-    it('supports useBasicCount and transacting', async function () {
-        const { bookshelf, modelState } = createBookshelf({ countRows: [{ aggregate: 1 }] });
+    it('passes the transacting option through to the count query', async function () {
+        const {bookshelf, modelState} = createBookshelf({countRows: [{aggregate: 1}]});
         const model = new bookshelf.Model();
 
         await model.fetchPage({
@@ -226,111 +207,6 @@ describe('@tryghost/bookshelf-pagination', function () {
         });
 
         assert.equal(modelState.transacting, 'trx');
-        assert.equal(modelState.rawCalls[0], 'count(*) as aggregate');
-    });
-
-    it('uses distinct count query by default', async function () {
-        const { bookshelf, modelState } = createBookshelf({ countRows: [{ aggregate: 1 }] });
-        const model = new bookshelf.Model();
-
-        await model.fetchPage({ page: 2, limit: 10 });
-
-        assert.equal(modelState.rawCalls[0], 'count(distinct posts.id) as aggregate');
-    });
-
-    it('useSmartCount uses count(*) when no JOINs present', async function () {
-        const { bookshelf, modelState } = createBookshelf({ countRows: [{ aggregate: 1 }] });
-        const model = new bookshelf.Model();
-
-        await model.fetchPage({ page: 1, limit: 10, useSmartCount: true });
-
-        assert.equal(modelState.rawCalls[0], 'count(*) as aggregate');
-    });
-
-    it('useSmartCount uses count(*) when a subquery-with-JOIN appears in WHERE', async function () {
-        // Regression: JOIN inside a `where id in (subquery)` is a `where`
-        // grouping on the outer query, not a `join` — the outer row set is
-        // still unique per base row, so count(*) is safe.
-        const {bookshelf, modelState} = createBookshelf({countRows: [{aggregate: 1}]});
-        const model = new bookshelf.Model();
-
-        stubCountQuery(model, {
-            statements: [{grouping: 'where', type: 'whereIn', column: 'posts.id'}],
-            single: {table: 'posts'}
-        });
-
-        await model.fetchPage({page: 1, limit: 10, useSmartCount: true});
-
-        assert.equal(modelState.rawCalls[0], 'count(*) as aggregate');
-    });
-
-    it('useSmartCount uses distinct count when the query has a join grouping', async function () {
-        const {bookshelf, modelState} = createBookshelf({countRows: [{aggregate: 1}]});
-        const model = new bookshelf.Model();
-
-        stubCountQuery(model, {
-            statements: [{grouping: 'join', type: 'inner', table: 'authors'}],
-            single: {table: 'posts'}
-        });
-
-        await model.fetchPage({page: 1, limit: 10, useSmartCount: true});
-
-        assert.equal(modelState.rawCalls[0], 'count(distinct posts.id) as aggregate');
-    });
-
-    it('useSmartCount uses distinct count when the FROM source is a derived table', async function () {
-        const {bookshelf, modelState} = createBookshelf({countRows: [{aggregate: 1}]});
-        const model = new bookshelf.Model();
-
-        stubCountQuery(model, {
-            statements: [],
-            single: {table: {fakeBuilder: true}}
-        });
-
-        await model.fetchPage({page: 1, limit: 10, useSmartCount: true});
-
-        assert.equal(modelState.rawCalls[0], 'count(distinct posts.id) as aggregate');
-    });
-
-    it('useSmartCount uses count(*) when the query has only a CTE (with) grouping', async function () {
-        const {bookshelf, modelState} = createBookshelf({countRows: [{aggregate: 1}]});
-        const model = new bookshelf.Model();
-
-        stubCountQuery(model, {
-            statements: [{grouping: 'with', alias: 'cte'}],
-            single: {table: 'posts'}
-        });
-
-        await model.fetchPage({page: 1, limit: 10, useSmartCount: true});
-
-        assert.equal(modelState.rawCalls[0], 'count(*) as aggregate');
-    });
-
-    it('useSmartCount uses distinct count when the query has a union grouping', async function () {
-        const {bookshelf, modelState} = createBookshelf({countRows: [{aggregate: 1}]});
-        const model = new bookshelf.Model();
-
-        stubCountQuery(model, {
-            statements: [{grouping: 'union', all: false}],
-            single: {table: 'posts'}
-        });
-
-        await model.fetchPage({page: 1, limit: 10, useSmartCount: true});
-
-        assert.equal(modelState.rawCalls[0], 'count(distinct posts.id) as aggregate');
-    });
-
-    it('useSmartCount uses distinct count when FROM has comma-separated tables', async function () {
-        const {bookshelf, modelState} = createBookshelf({countRows: [{aggregate: 1}]});
-        const model = new bookshelf.Model();
-
-        stubCountQuery(model, {
-            single: {table: 'posts, tags'}
-        });
-
-        await model.fetchPage({page: 1, limit: 10, useSmartCount: true});
-
-        assert.equal(modelState.rawCalls[0], 'count(distinct posts.id) as aggregate');
     });
 
     it('handleRelation does not duplicate entries and ignores same-table properties', function () {

--- a/packages/bookshelf-pagination/test/pagination.test.js
+++ b/packages/bookshelf-pagination/test/pagination.test.js
@@ -16,7 +16,8 @@ function createBookshelf({ countRows, fetchResult, selectError, fetchError } = {
     };
 
     const countQuery = {
-        _sql: 'select * from `posts`',
+        _statements: [],
+        _single: {table: 'posts'},
         clone() {
             modelState.countCloned = true;
             return countQuery;
@@ -35,9 +36,6 @@ function createBookshelf({ countRows, fetchResult, selectError, fetchError } = {
                 return Promise.reject(selectError);
             }
             return Promise.resolve(countRows || [{ aggregate: 1 }]);
-        },
-        toSQL() {
-            return { sql: countQuery._sql };
         },
     };
 
@@ -77,6 +75,25 @@ function createBookshelf({ countRows, fetchResult, selectError, fetchError } = {
 
     paginationPlugin(bookshelf);
     return { bookshelf, modelState };
+}
+
+// Install `state` onto the fake query builder returned by `model.query()`
+// so that countQuery._statements / _single reflect the scenario under test.
+// Only the keys present on `state` are written.
+function stubCountQuery(model, state) {
+    const originalQuery = model.query;
+    model.query = function () {
+        const qb = originalQuery.apply(this, arguments);
+        if (arguments.length === 0) {
+            if (state.statements !== undefined) {
+                qb._statements = state.statements;
+            }
+            if (state.single !== undefined) {
+                qb._single = state.single;
+            }
+        }
+        return qb;
+    };
 }
 
 describe('@tryghost/bookshelf-pagination', function () {
@@ -230,108 +247,90 @@ describe('@tryghost/bookshelf-pagination', function () {
         assert.equal(modelState.rawCalls[0], 'count(*) as aggregate');
     });
 
-    it('useSmartCount uses count(*) when SQL has commas outside FROM', async function () {
-        const { bookshelf, modelState } = createBookshelf({ countRows: [{ aggregate: 1 }] });
+    it('useSmartCount uses count(*) when a subquery-with-JOIN appears in WHERE', async function () {
+        // Regression: JOIN inside a `where id in (subquery)` is a `where`
+        // grouping on the outer query, not a `join` — the outer row set is
+        // still unique per base row, so count(*) is safe.
+        const {bookshelf, modelState} = createBookshelf({countRows: [{aggregate: 1}]});
         const model = new bookshelf.Model();
 
-        // Simulate a typical single-table query with multiple selected columns
-        const originalQuery = model.query;
-        model.query = function () {
-            const qb = originalQuery.apply(this, arguments);
-            if (arguments.length === 0) {
-                qb._sql =
-                    'select `posts`.`id`, `posts`.`title` from `posts` where `posts`.`status` = ?';
-            }
-            return qb;
-        };
-
-        await model.fetchPage({ page: 1, limit: 10, useSmartCount: true });
-
-        assert.equal(modelState.rawCalls[0], 'count(*) as aggregate');
-    });
-
-    for (const [joinType, sql] of [
-        ['leftJoin', 'select * from `posts` left join `tags` on `posts`.`id` = `tags`.`post_id`'],
-        ['rightJoin', 'select * from `posts` right join `tags` on `posts`.`id` = `tags`.`post_id`'],
-        ['innerJoin', 'select * from `posts` inner join `tags` on `posts`.`id` = `tags`.`post_id`'],
-        ['joinRaw', 'select * from `posts` LEFT JOIN tags ON posts.id = tags.post_id'],
-    ]) {
-        it(`useSmartCount uses distinct count when ${joinType} is present`, async function () {
-            const { bookshelf, modelState } = createBookshelf({ countRows: [{ aggregate: 1 }] });
-            const model = new bookshelf.Model();
-
-            // Simulate a JOIN in the compiled SQL
-            const originalQuery = model.query;
-            model.query = function () {
-                const qb = originalQuery.apply(this, arguments);
-                if (arguments.length === 0) {
-                    qb._sql = sql;
-                }
-                return qb;
-            };
-
-            await model.fetchPage({ page: 1, limit: 10, useSmartCount: true });
-
-            assert.equal(modelState.rawCalls[0], 'count(distinct posts.id) as aggregate');
+        stubCountQuery(model, {
+            statements: [{grouping: 'where', type: 'whereIn', column: 'posts.id'}],
+            single: {table: 'posts'}
         });
-    }
-
-    it('useSmartCount uses distinct count when comma-separated FROM sources are present', async function () {
-        const { bookshelf, modelState } = createBookshelf({ countRows: [{ aggregate: 1 }] });
-        const model = new bookshelf.Model();
-
-        const originalQuery = model.query;
-        model.query = function () {
-            const qb = originalQuery.apply(this, arguments);
-            if (arguments.length === 0) {
-                qb._sql = 'select * from `posts`, `tags` where `posts`.`id` = `tags`.`post_id`';
-            }
-            return qb;
-        };
-
-        await model.fetchPage({ page: 1, limit: 10, useSmartCount: true });
-
-        assert.equal(modelState.rawCalls[0], 'count(distinct posts.id) as aggregate');
-    });
-
-    it('useSmartCount supports SQL fragments returned as an array', async function () {
-        const {bookshelf, modelState} = createBookshelf({countRows: [{aggregate: 1}]});
-        const model = new bookshelf.Model();
-
-        const originalQuery = model.query;
-        model.query = function () {
-            const qb = originalQuery.apply(this, arguments);
-            if (arguments.length === 0) {
-                qb.toSQL = () => [
-                    {sql: 'select *'},
-                    {},
-                    {sql: 'from `posts`, `tags` where `posts`.`id` = `tags`.`post_id`'}
-                ];
-            }
-            return qb;
-        };
-
-        await model.fetchPage({page: 1, limit: 10, useSmartCount: true});
-
-        assert.equal(modelState.rawCalls[0], 'count(distinct posts.id) as aggregate');
-    });
-
-    it('useSmartCount falls back safely when compiled SQL is missing', async function () {
-        const {bookshelf, modelState} = createBookshelf({countRows: [{aggregate: 1}]});
-        const model = new bookshelf.Model();
-
-        const originalQuery = model.query;
-        model.query = function () {
-            const qb = originalQuery.apply(this, arguments);
-            if (arguments.length === 0) {
-                qb.toSQL = () => ({});
-            }
-            return qb;
-        };
 
         await model.fetchPage({page: 1, limit: 10, useSmartCount: true});
 
         assert.equal(modelState.rawCalls[0], 'count(*) as aggregate');
+    });
+
+    it('useSmartCount uses distinct count when the query has a join grouping', async function () {
+        const {bookshelf, modelState} = createBookshelf({countRows: [{aggregate: 1}]});
+        const model = new bookshelf.Model();
+
+        stubCountQuery(model, {
+            statements: [{grouping: 'join', type: 'inner', table: 'authors'}],
+            single: {table: 'posts'}
+        });
+
+        await model.fetchPage({page: 1, limit: 10, useSmartCount: true});
+
+        assert.equal(modelState.rawCalls[0], 'count(distinct posts.id) as aggregate');
+    });
+
+    it('useSmartCount uses distinct count when the FROM source is a derived table', async function () {
+        const {bookshelf, modelState} = createBookshelf({countRows: [{aggregate: 1}]});
+        const model = new bookshelf.Model();
+
+        stubCountQuery(model, {
+            statements: [],
+            single: {table: {fakeBuilder: true}}
+        });
+
+        await model.fetchPage({page: 1, limit: 10, useSmartCount: true});
+
+        assert.equal(modelState.rawCalls[0], 'count(distinct posts.id) as aggregate');
+    });
+
+    it('useSmartCount uses count(*) when the query has only a CTE (with) grouping', async function () {
+        const {bookshelf, modelState} = createBookshelf({countRows: [{aggregate: 1}]});
+        const model = new bookshelf.Model();
+
+        stubCountQuery(model, {
+            statements: [{grouping: 'with', alias: 'cte'}],
+            single: {table: 'posts'}
+        });
+
+        await model.fetchPage({page: 1, limit: 10, useSmartCount: true});
+
+        assert.equal(modelState.rawCalls[0], 'count(*) as aggregate');
+    });
+
+    it('useSmartCount uses distinct count when the query has a union grouping', async function () {
+        const {bookshelf, modelState} = createBookshelf({countRows: [{aggregate: 1}]});
+        const model = new bookshelf.Model();
+
+        stubCountQuery(model, {
+            statements: [{grouping: 'union', all: false}],
+            single: {table: 'posts'}
+        });
+
+        await model.fetchPage({page: 1, limit: 10, useSmartCount: true});
+
+        assert.equal(modelState.rawCalls[0], 'count(distinct posts.id) as aggregate');
+    });
+
+    it('useSmartCount uses distinct count when FROM has comma-separated tables', async function () {
+        const {bookshelf, modelState} = createBookshelf({countRows: [{aggregate: 1}]});
+        const model = new bookshelf.Model();
+
+        stubCountQuery(model, {
+            single: {table: 'posts, tags'}
+        });
+
+        await model.fetchPage({page: 1, limit: 10, useSmartCount: true});
+
+        assert.equal(modelState.rawCalls[0], 'count(distinct posts.id) as aggregate');
     });
 
     it('handleRelation does not duplicate entries and ignores same-table properties', function () {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -175,9 +175,18 @@ importers:
         specifier: 4.18.1
         version: 4.18.1
     devDependencies:
+      bookshelf:
+        specifier: 1.2.0
+        version: 1.2.0(knex@3.2.9(sqlite3@5.1.7))
+      knex:
+        specifier: 3.2.9
+        version: 3.2.9(sqlite3@5.1.7)
       sinon:
         specifier: 'catalog:'
         version: 21.1.2
+      sqlite3:
+        specifier: 5.1.7
+        version: 5.1.7
 
   packages/bookshelf-plugins:
     dependencies:
@@ -241,7 +250,7 @@ importers:
     devDependencies:
       knex:
         specifier: 3.2.9
-        version: 3.2.9
+        version: 3.2.9(sqlite3@5.1.7)
 
   packages/debug:
     dependencies:
@@ -592,7 +601,7 @@ importers:
         version: 7.2.0
       knex:
         specifier: 3.2.9
-        version: 3.2.9
+        version: 3.2.9(sqlite3@5.1.7)
       nock:
         specifier: 14.0.12
         version: 14.0.12
@@ -1723,6 +1732,9 @@ packages:
     resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@gar/promisify@1.1.3':
+    resolution: {integrity: sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==}
+
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
     engines: {node: '>=18.18.0'}
@@ -1829,6 +1841,14 @@ packages:
   '@noble/hashes@1.8.0':
     resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
     engines: {node: ^14.21.3 || >=16}
+
+  '@npmcli/fs@1.1.1':
+    resolution: {integrity: sha512-8KG5RD0GVP4ydEzRn/I4BNDuxDtqVbOdm8675T49OIG/NGhaK0pjPX7ZcDlvKYbA+ulvVK3ztfcF4uBdOxuJbQ==}
+
+  '@npmcli/move-file@1.1.2':
+    resolution: {integrity: sha512-1SUf/Cg2GzGDyaf15aR9St9TWlb+XvbZXWpDx8YKs7MLzMH/BCeopv+y9vzrzgkfykCGuWOlSu3mZhj2+FQcrg==}
+    engines: {node: '>=10'}
+    deprecated: This functionality has been moved to @npmcli/fs
 
   '@nx/devkit@22.6.5':
     resolution: {integrity: sha512-9kvAI+kk2pfEXLqS8OyjI9XvWmp+Gdn7jPfxDAz8BOqxMyPy3p5hYl+jc4TIsLOWunAFl8azqrcYsHzEpaWCIA==}
@@ -2472,6 +2492,10 @@ packages:
   '@swc/helpers@0.5.21':
     resolution: {integrity: sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==}
 
+  '@tootallnate/once@1.1.2':
+    resolution: {integrity: sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==}
+    engines: {node: '>= 6'}
+
   '@tryghost/bunyan-rotating-filestream@0.0.7':
     resolution: {integrity: sha512-dswM+dxG8J7WpVoSjzAdoWXqqB5Dg0C2T7Zh6eoUvl5hkA8yWWJi/fS4jNXlHF700lWQ0g8/t+leJ7SGSWd+aw==}
 
@@ -2662,6 +2686,9 @@ packages:
     resolution: {integrity: sha512-nrUSn7hzt7J6JWgWGz78ZYI8wj+gdIJdk0Ynjpp8l+trkn58Uqsf6RYrYkEK+3X18EX+TNdtJI0WxAtc+L84SQ==}
     hasBin: true
 
+  abbrev@1.1.1:
+    resolution: {integrity: sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==}
+
   abort-controller@3.0.0:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
     engines: {node: '>=6.5'}
@@ -2687,6 +2714,18 @@ packages:
   address@1.2.2:
     resolution: {integrity: sha512-4B/qKCfeE/ODUaAUpSwfzazo5x29WD4r3vXiWsB7I2mSDAihwEqKO+g8GELZUQSSAo5e1XTYh3ZVfLyxBc12nA==}
     engines: {node: '>= 10.0.0'}
+
+  agent-base@6.0.2:
+    resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
+    engines: {node: '>= 6.0.0'}
+
+  agentkeepalive@4.6.0:
+    resolution: {integrity: sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==}
+    engines: {node: '>= 8.0.0'}
+
+  aggregate-error@3.1.0:
+    resolution: {integrity: sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==}
+    engines: {node: '>=8'}
 
   ajv@6.14.0:
     resolution: {integrity: sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==}
@@ -2726,6 +2765,9 @@ packages:
   append-field@1.0.0:
     resolution: {integrity: sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==}
 
+  aproba@2.1.0:
+    resolution: {integrity: sha512-tLIEcj5GuR2RSTnxNKdkK0dJ/GrC7P38sUkiDmDuHfsHmbagTFAxDVIBltoklXEVIQ/f14IL8IMJ5pn9Hez1Ew==}
+
   archiver-utils@5.0.2:
     resolution: {integrity: sha512-wuLJMmIBQYCsGZgYLTy5FIB2pF6Lfb6cXMSF8Qywwk3t20zWnAi7zLcQFdKQmIB8wyZpY5ER38x08GbwtR2cLA==}
     engines: {node: '>= 14'}
@@ -2733,6 +2775,11 @@ packages:
   archiver@7.0.1:
     resolution: {integrity: sha512-ZcbTaIqJOfCc03QwD468Unz/5Ir8ATtvAHsK+FdXbDIbGfihqh9mrvdcYunQzqn4HrvWWaFyaxJhGZagaJJpPQ==}
     engines: {node: '>= 14'}
+
+  are-we-there-yet@3.0.1:
+    resolution: {integrity: sha512-QZW4EDmGwlYur0Yyf/b2uGucHQMa8aFUP7eu9ddR73vvhFyt4V0Vl3QHPcTNJ8l6qYOBdxgXdnBXQrHilfRQBg==}
+    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
+    deprecated: This package is no longer supported.
 
   arg@4.1.3:
     resolution: {integrity: sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==}
@@ -2890,6 +2937,9 @@ packages:
     resolution: {integrity: sha512-GlF5wPWnSa/X5LKM1o0wz0suXIINz1iHRLvTS+sLyi7XPbe5ycmYI3DlZqVGZZtDgl4DmasFg7gOB3JYbphV5g==}
     hasBin: true
 
+  bindings@1.5.0:
+    resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
+
   bintrees@1.0.2:
     resolution: {integrity: sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==}
 
@@ -2902,6 +2952,12 @@ packages:
   body-parser@2.2.2:
     resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
     engines: {node: '>=18'}
+
+  bookshelf@1.2.0:
+    resolution: {integrity: sha512-rm04YpHkLej6bkNezKUQjzuXV30rbyEHQoaKvfQ3fOyLYxPeB18uBL+h2t6SmeXjfsB+aReMmbhkMF/lUTbtMA==}
+    engines: {node: '>=6'}
+    peerDependencies:
+      knex: '>=0.15.0 <0.22.0'
 
   bowser@2.14.1:
     resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
@@ -2964,6 +3020,10 @@ packages:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
     engines: {node: '>= 0.8'}
 
+  cacache@15.3.0:
+    resolution: {integrity: sha512-VVdYzXEn+cnbXpFgWs5hTT7OScegHVmLhJIR8Ufqk3iFD6A6j5iSX1KuBTfNEv4tdJWE2PzA6IVFtcLC7fN9wQ==}
+    engines: {node: '>= 10'}
+
   cacheable-lookup@7.0.0:
     resolution: {integrity: sha512-+qJyx4xiKra8mZrcwhjMRMUhD5NR1R8esPkzIYxX96JiecFoxAXFuz/GpR3+ev4PE1WamHip78wV0vcmPQtp8w==}
     engines: {node: '>=14.16'}
@@ -3010,9 +3070,20 @@ packages:
     resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
 
+  chownr@1.1.4:
+    resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
+
+  chownr@2.0.0:
+    resolution: {integrity: sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==}
+    engines: {node: '>=10'}
+
   ci-info@4.4.0:
     resolution: {integrity: sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==}
     engines: {node: '>=8'}
+
+  clean-stack@2.2.0:
+    resolution: {integrity: sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==}
+    engines: {node: '>=6'}
 
   cli-cursor@3.1.0:
     resolution: {integrity: sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==}
@@ -3039,6 +3110,10 @@ packages:
 
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  color-support@1.1.3:
+    resolution: {integrity: sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==}
+    hasBin: true
 
   colorette@2.0.19:
     resolution: {integrity: sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ==}
@@ -3088,6 +3163,9 @@ packages:
   concat-stream@2.0.0:
     resolution: {integrity: sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==}
     engines: {'0': node >= 6.0}
+
+  console-control-strings@1.1.0:
+    resolution: {integrity: sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==}
 
   consolidate@0.15.1:
     resolution: {integrity: sha512-DW46nrsMJgy9kqAbPt5rKaCr7uFtpo4mSUvLHIUbJEjm0vo+aY5QLwBUq3FK4tRnJr/X0Psc0C4jf/h+HtXSMw==}
@@ -3299,6 +3377,9 @@ packages:
     resolution: {integrity: sha512-piICUB6ei4IlTv1+653yq5+KoqfBYmj9bw6LqXoOneTMDXk5nM1qt12mFW1caG3LlJXEKW1Bp0WggEmIfQB34g==}
     engines: {node: '>= 14'}
 
+  create-error@0.3.1:
+    resolution: {integrity: sha512-n/Q4aSCtYuuDneEW5Q+nd0IIZwbwmX/oF6wKcDUhXGJNwhmp2WHEoWKz7X+/H7rBtjimInW7f0ceouxU0SmuzQ==}
+
   create-require@1.1.1:
     resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
 
@@ -3362,6 +3443,14 @@ packages:
     resolution: {integrity: sha512-oj7KWToJuuxlPr7VV0vabvxEIiqNMo+q0NueIiL3XhtwC6FVOX7Hr1c0C4eD0bmf7Zr+S/dSf2xvkH3Ad6sU3Q==}
     engines: {node: '>=20'}
 
+  decompress-response@6.0.0:
+    resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
+    engines: {node: '>=10'}
+
+  deep-extend@0.6.0:
+    resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
+    engines: {node: '>=4.0.0'}
+
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
@@ -3375,6 +3464,9 @@ packages:
   delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
+
+  delegates@1.0.0:
+    resolution: {integrity: sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==}
 
   depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
@@ -3440,12 +3532,22 @@ packages:
     resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
     engines: {node: '>= 0.8'}
 
+  encoding@0.1.13:
+    resolution: {integrity: sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==}
+
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
   enquirer@2.3.6:
     resolution: {integrity: sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==}
     engines: {node: '>=8.6'}
+
+  env-paths@2.2.1:
+    resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
+    engines: {node: '>=6'}
+
+  err-code@2.0.3:
+    resolution: {integrity: sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==}
 
   error-ex@1.3.4:
     resolution: {integrity: sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==}
@@ -3562,6 +3664,10 @@ packages:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
 
+  expand-template@2.0.3:
+    resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
+    engines: {node: '>=6'}
+
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
@@ -3630,6 +3736,9 @@ packages:
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
     engines: {node: '>=16.0.0'}
+
+  file-uri-to-path@1.0.0:
+    resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
 
   finalhandler@2.1.1:
     resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
@@ -3717,6 +3826,10 @@ packages:
     resolution: {integrity: sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==}
     engines: {node: '>=14.14'}
 
+  fs-minipass@2.1.0:
+    resolution: {integrity: sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==}
+    engines: {node: '>= 8'}
+
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
@@ -3727,6 +3840,11 @@ packages:
 
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  gauge@4.0.4:
+    resolution: {integrity: sha512-f9m+BEN5jkg6a0fZjleidjN51VE1X+mPFQ2DJ0uv1V39oCLCbsGe6yjbBnp7eK7z/+GAon99a3nHuqbuuthyPg==}
+    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
+    deprecated: This package is no longer supported.
 
   gelf-stream@1.1.1:
     resolution: {integrity: sha512-kCzCfI6DJ8+aaDhwMcsNm2l6CsBj6y4Is6CCxH2W9sYnZGcXg9WmJ/iZMoJVO6uTwTRL7dbIioAS8lCuGUXSFA==}
@@ -3764,6 +3882,9 @@ packages:
 
   getopts@2.3.0:
     resolution: {integrity: sha512-5eDf9fuSXwxBL6q5HX+dhDj+dslFGWzU5thZ9kNKUkcPtaPdatmUFKwHFrLb/uf/WpA4BHET+AX3Scl56cAjpA==}
+
+  github-from-package@0.0.0:
+    resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
 
   glob-parent@6.0.2:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
@@ -3809,6 +3930,9 @@ packages:
     resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
     engines: {node: '>= 0.4'}
 
+  has-unicode@2.0.1:
+    resolution: {integrity: sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==}
+
   hasown@2.0.3:
     resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
     engines: {node: '>= 0.4'}
@@ -3827,12 +3951,27 @@ packages:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
 
+  http-proxy-agent@4.0.1:
+    resolution: {integrity: sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==}
+    engines: {node: '>= 6'}
+
   http2-wrapper@2.2.1:
     resolution: {integrity: sha512-V5nVw1PAOgfI3Lmeaj2Exmeg7fenjhRUgz1lPSezy1CuhPYbgQtbQj4jZfEAEMlaL+vupsvhjqCyjzob0yxsmQ==}
     engines: {node: '>=10.19.0'}
 
+  https-proxy-agent@5.0.1:
+    resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
+    engines: {node: '>= 6'}
+
   human-interval@2.0.1:
     resolution: {integrity: sha512-r4Aotzf+OtKIGQCB3odUowy4GfUDTy3aTWTfLd7ZF2gBCy3XW3v/dJLRefZnOFFnjqs5B1TypvS8WarpBkYUNQ==}
+
+  humanize-ms@1.2.1:
+    resolution: {integrity: sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==}
+
+  iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
 
   iconv-lite@0.7.2:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
@@ -3857,12 +3996,26 @@ packages:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
 
+  indent-string@4.0.0:
+    resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
+    engines: {node: '>=8'}
+
+  infer-owner@1.0.4:
+    resolution: {integrity: sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==}
+
+  inflection@1.13.4:
+    resolution: {integrity: sha512-6I/HUDeYFfuNCVS3td055BaXBwKYuzw7K3ExVMStBowKo9oOAMJIXIHvdyR3iboTCp1b+1i5DSkIZTcwIktuDw==}
+    engines: {'0': node >= 0.4.0}
+
   inflight@1.0.6:
     resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
     deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  ini@1.3.8:
+    resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
 
   ini@2.0.0:
     resolution: {integrity: sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==}
@@ -3871,6 +4024,10 @@ packages:
   interpret@2.2.0:
     resolution: {integrity: sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw==}
     engines: {node: '>= 0.10'}
+
+  ip-address@10.1.0:
+    resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
+    engines: {node: '>= 12'}
 
   ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
@@ -3915,6 +4072,9 @@ packages:
   is-invalid-path@0.1.0:
     resolution: {integrity: sha512-aZMG0T3F34mTg4eTdszcGXx54oiZ4NtHSft3hWNJMGJXUUqdIj3cOZuHcU0nCWWcY3jd7yRe/3AEm3vSNTpBGQ==}
     engines: {node: '>=0.10.0'}
+
+  is-lambda@1.0.1:
+    resolution: {integrity: sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ==}
 
   is-node-process@1.2.0:
     resolution: {integrity: sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==}
@@ -4232,6 +4392,10 @@ packages:
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
+  lru-cache@6.0.0:
+    resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
+    engines: {node: '>=10'}
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
@@ -4247,6 +4411,10 @@ packages:
 
   make-error@1.3.6:
     resolution: {integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==}
+
+  make-fetch-happen@9.1.0:
+    resolution: {integrity: sha512-+zopwDy7DNknmwPQplem5lAZX/eCOzSvSNNcSKm5eVwTkOBzoktEfXsa9L23J/GIRhxRsaxzkPEhrJEpE2F4Gg==}
+    engines: {node: '>= 10'}
 
   makeerror@1.0.12:
     resolution: {integrity: sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==}
@@ -4299,6 +4467,10 @@ packages:
     resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
     engines: {node: '>=6'}
 
+  mimic-response@3.1.0:
+    resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
+    engines: {node: '>=10'}
+
   mimic-response@4.0.0:
     resolution: {integrity: sha512-e5ISH9xMYU0DzrT+jl8q2ze9D6eWBto+I8CNpe+VI+K2J/F/k3PdkdTdz4wvGVH4NTpo+NRYTVIuMQEMMcsLqg==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -4328,12 +4500,52 @@ packages:
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
+  minipass-collect@1.0.2:
+    resolution: {integrity: sha512-6T6lH0H8OG9kITm/Jm6tdooIbogG9e0tLgpY6mphXSm/A9u8Nq1ryBG+Qspiub9LjWlBPsPS3tWQ/Botq4FdxA==}
+    engines: {node: '>= 8'}
+
+  minipass-fetch@1.4.1:
+    resolution: {integrity: sha512-CGH1eblLq26Y15+Azk7ey4xh0J/XfJfrCox5LDJiKqI2Q2iwOLOKrlmIaODiSQS8d18jalF6y2K2ePUm0CmShw==}
+    engines: {node: '>=8'}
+
+  minipass-flush@1.0.7:
+    resolution: {integrity: sha512-TbqTz9cUwWyHS2Dy89P3ocAGUGxKjjLuR9z8w4WUTGAVgEj17/4nhgo2Du56i0Fm3Pm30g4iA8Lcqctc76jCzA==}
+    engines: {node: '>= 8'}
+
+  minipass-pipeline@1.2.4:
+    resolution: {integrity: sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==}
+    engines: {node: '>=8'}
+
+  minipass-sized@1.0.3:
+    resolution: {integrity: sha512-MbkQQ2CTiBMlA2Dm/5cY+9SWFEN8pzzOXi6rlM5Xxq0Yqbda5ZQy9sU75a673FE9ZK0Zsbr6Y5iP6u9nktfg2g==}
+    engines: {node: '>=8'}
+
+  minipass@3.3.6:
+    resolution: {integrity: sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==}
+    engines: {node: '>=8'}
+
+  minipass@5.0.0:
+    resolution: {integrity: sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==}
+    engines: {node: '>=8'}
+
   minipass@7.1.3:
     resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
     engines: {node: '>=16 || 14 >=14.17'}
 
+  minizlib@2.1.2:
+    resolution: {integrity: sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==}
+    engines: {node: '>= 8'}
+
+  mkdirp-classic@0.5.3:
+    resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
+
   mkdirp@0.5.6:
     resolution: {integrity: sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==}
+    hasBin: true
+
+  mkdirp@1.0.4:
+    resolution: {integrity: sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==}
+    engines: {node: '>=10'}
     hasBin: true
 
   moment-timezone@0.5.48:
@@ -4370,6 +4582,9 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  napi-build-utils@2.0.0:
+    resolution: {integrity: sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==}
+
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
@@ -4381,6 +4596,10 @@ packages:
     resolution: {integrity: sha512-zIdGUrPRFTUELUvr3Gmc7KZ2Sw/h1PiVM0Af/oHB6zgnV1ikqSfRk+TOufi79aHYCW3NiOXmr1BP5nWbzojLaA==}
     hasBin: true
 
+  negotiator@0.6.4:
+    resolution: {integrity: sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==}
+    engines: {node: '>= 0.6'}
+
   negotiator@1.0.0:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
@@ -4388,6 +4607,18 @@ packages:
   nock@14.0.12:
     resolution: {integrity: sha512-kZM3bHV0KzhHH6E2eRszHyML/w87AUzLBwupNTHohtYWP9fZYgUPmCbSKq6ITfEEmHqN4/p0MscvUipT4P5Qsg==}
     engines: {node: '>=18.20.0 <20 || >=20.12.1'}
+
+  node-abi@3.89.0:
+    resolution: {integrity: sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==}
+    engines: {node: '>=10'}
+
+  node-addon-api@7.1.1:
+    resolution: {integrity: sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==}
+
+  node-gyp@8.4.1:
+    resolution: {integrity: sha512-olTJRgUtAb/hOXG0E93wZDs5YiJlgbXxTwQAFHyNlRsXQnYzUaF2aGgujZbw+hR8aF4ZG/rST57bWMWD16jr9w==}
+    engines: {node: '>= 10.12.0'}
+    hasBin: true
 
   node-int64@0.4.0:
     resolution: {integrity: sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==}
@@ -4409,6 +4640,11 @@ packages:
     resolution: {integrity: sha512-0PF8Yb1yZuQfQbq+5/pZJrtF6WQcjTd5/S4JOHs9PGFxuTqoB/icwuB44pOdURHJbRKX1PPoJZtY7R4VUoCC8w==}
     engines: {node: '>=6.0.0'}
 
+  nopt@5.0.0:
+    resolution: {integrity: sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==}
+    engines: {node: '>=6'}
+    hasBin: true
+
   normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
     engines: {node: '>=0.10.0'}
@@ -4420,6 +4656,11 @@ packages:
   npm-run-path@4.0.1:
     resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
     engines: {node: '>=8'}
+
+  npmlog@6.0.2:
+    resolution: {integrity: sha512-/vBvz5Jfr9dT/aFWd0FIRf+T/Q2WBsLENygUaFUqstqsycmZAP/t5BvFJTK0viFmSUxiUKTUplWy5vt+rvKIxg==}
+    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
+    deprecated: This package is no longer supported.
 
   numbered@1.1.0:
     resolution: {integrity: sha512-pv/ue2Odr7IfYOO0byC1KgBI10wo5YDauLhxY6/saNzAdAs0r1SotGCPzzCLNPL0xtrAwWRialLu23AAu9xO1g==}
@@ -4512,6 +4753,10 @@ packages:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
 
+  p-map@4.0.0:
+    resolution: {integrity: sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==}
+    engines: {node: '>=10'}
+
   p-timeout@3.2.0:
     resolution: {integrity: sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==}
     engines: {node: '>=8'}
@@ -4601,6 +4846,12 @@ packages:
     resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
     engines: {node: ^10 || ^12 || >=14}
 
+  prebuild-install@7.1.3:
+    resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
+    engines: {node: '>=10'}
+    deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
+    hasBin: true
+
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
@@ -4623,6 +4874,18 @@ packages:
   prom-client@15.1.3:
     resolution: {integrity: sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==}
     engines: {node: ^16 || ^18 || >=20}
+
+  promise-inflight@1.0.1:
+    resolution: {integrity: sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==}
+    peerDependencies:
+      bluebird: '*'
+    peerDependenciesMeta:
+      bluebird:
+        optional: true
+
+  promise-retry@2.0.1:
+    resolution: {integrity: sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==}
+    engines: {node: '>=10'}
 
   propagate@2.0.1:
     resolution: {integrity: sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==}
@@ -4668,6 +4931,10 @@ packages:
   raw-body@3.0.2:
     resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
     engines: {node: '>= 0.10'}
+
+  rc@1.2.8:
+    resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
+    hasBin: true
 
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
@@ -4740,6 +5007,10 @@ packages:
     resolution: {integrity: sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==}
     engines: {node: '>=8'}
 
+  retry@0.12.0:
+    resolution: {integrity: sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==}
+    engines: {node: '>= 4'}
+
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
@@ -4749,6 +5020,11 @@ packages:
 
   rimraf@2.4.5:
     resolution: {integrity: sha512-J5xnxTyqaiw06JjMftq7L9ouA448dw/E7dKghkP9WpKNuwmARNNg+Gk8/u5ryb9N/Yo2+z3MCwuqFK/+qPOPfQ==}
+    deprecated: Rimraf versions prior to v4 are no longer supported
+    hasBin: true
+
+  rimraf@3.0.2:
+    resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
     deprecated: Rimraf versions prior to v4 are no longer supported
     hasBin: true
 
@@ -4799,6 +5075,9 @@ packages:
     resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
     engines: {node: '>= 18'}
 
+  set-blocking@2.0.0:
+    resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
+
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
 
@@ -4836,6 +5115,12 @@ packages:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
 
+  simple-concat@1.0.1:
+    resolution: {integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==}
+
+  simple-get@4.0.1:
+    resolution: {integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==}
+
   sinon@21.1.2:
     resolution: {integrity: sha512-FS6mN+/bx7e2ajpXkEmOcWB6xBzWiuNoAQT18/+a20SS4U7FSYl8Ms7N6VTUxN/1JAjkx7aXp+THMC8xdpp0gA==}
 
@@ -4843,9 +5128,21 @@ packages:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
 
+  smart-buffer@4.2.0:
+    resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
+    engines: {node: '>= 6.0.0', npm: '>= 3.0.0'}
+
   smol-toml@1.6.1:
     resolution: {integrity: sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==}
     engines: {node: '>= 18'}
+
+  socks-proxy-agent@6.2.1:
+    resolution: {integrity: sha512-a6KW9G+6B3nWZ1yB8G7pJwL3ggLy1uTzKAgCb7ttblwqdz9fMGJUuTy3uFzEP48FAs9FLILlmzDlE2JJhVQaXQ==}
+    engines: {node: '>= 10'}
+
+  socks@2.8.7:
+    resolution: {integrity: sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==}
+    engines: {node: '>= 10.0.0', npm: '>= 3.0.0'}
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -4864,6 +5161,13 @@ packages:
 
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
+
+  sqlite3@5.1.7:
+    resolution: {integrity: sha512-GGIyOiFaG+TUra3JIfkI/zGP8yZYLPQ0pl1bH+ODjiX57sPhrLU5sQJn1y9bDKZUFYkX1crlrPfSYt0BKKdkog==}
+
+  ssri@8.0.1:
+    resolution: {integrity: sha512-97qShzy1AiyxvPNIkLWoGua7xoQzzPjQ0HAH4B0rWKo7SZ6USuPcrUiAFrws0UH8RrbWmgq3LMTObhPIHbbBeQ==}
+    engines: {node: '>= 8'}
 
   stack-utils@2.0.6:
     resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}
@@ -4919,6 +5223,10 @@ packages:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
     engines: {node: '>=4'}
 
+  strip-json-comments@2.0.1:
+    resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
+    engines: {node: '>=0.10.0'}
+
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
@@ -4958,12 +5266,20 @@ packages:
     resolution: {integrity: sha512-iK5/YhZxq5GO5z8wb0bY1317uDF3Zjpha0QFFLA8/trAoiLbQD0HUbMesEaxyzUgDxi2QlcbM8IvqOlEjgoXBA==}
     engines: {node: '>=12.17'}
 
+  tar-fs@2.1.4:
+    resolution: {integrity: sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==}
+
   tar-stream@2.2.0:
     resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
     engines: {node: '>=6'}
 
   tar-stream@3.1.8:
     resolution: {integrity: sha512-U6QpVRyCGHva435KoNWy9PRoi2IFYCgtEhq9nmrPPpbRacPs9IH4aJ3gbrFC8dPcXvdSZ4XXfXT5Fshbp2MtlQ==}
+
+  tar@6.2.1:
+    resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
+    engines: {node: '>=10'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   tarn@3.0.2:
     resolution: {integrity: sha512-51LAVKUSZSVfI05vjPESNc5vwqqZpbXCsU+/+wxlOrUjk2SnFTt97v9ZgQrD4YmxYW1Px6w2KjaDitCfkvgxMQ==}
@@ -5047,6 +5363,9 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
+  tunnel-agent@0.6.0:
+    resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
+
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
@@ -5120,6 +5439,12 @@ packages:
   unidecode@1.1.0:
     resolution: {integrity: sha512-GIp57N6DVVJi8dpeIU6/leJGdv7W65ZSXFLFiNmxvexXkc0nXdqUvhA/qL9KqBKsILxMwg5MnmYNOIDJLb5JVA==}
     engines: {node: '>= 0.4.12'}
+
+  unique-filename@1.1.1:
+    resolution: {integrity: sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==}
+
+  unique-slug@2.0.2:
+    resolution: {integrity: sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==}
 
   universalify@2.0.1:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
@@ -5259,6 +5584,9 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
+  wide-align@1.1.5:
+    resolution: {integrity: sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==}
+
   word-wrap@1.2.5:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
@@ -5291,6 +5619,9 @@ packages:
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
+  yallist@4.0.0:
+    resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
 
   yaml@1.10.3:
     resolution: {integrity: sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==}
@@ -6655,6 +6986,9 @@ snapshots:
       '@eslint/core': 0.17.0
       levn: 0.4.1
 
+  '@gar/promisify@1.1.3':
+    optional: true
+
   '@humanfs/core@0.19.2':
     dependencies:
       '@humanfs/types': 0.15.0
@@ -6799,6 +7133,18 @@ snapshots:
     optional: true
 
   '@noble/hashes@1.8.0': {}
+
+  '@npmcli/fs@1.1.1':
+    dependencies:
+      '@gar/promisify': 1.1.3
+      semver: 7.7.4
+    optional: true
+
+  '@npmcli/move-file@1.1.2':
+    dependencies:
+      mkdirp: 1.0.4
+      rimraf: 3.0.2
+    optional: true
 
   '@nx/devkit@22.6.5(nx@22.6.5)':
     dependencies:
@@ -7382,6 +7728,9 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  '@tootallnate/once@1.1.2':
+    optional: true
+
   '@tryghost/bunyan-rotating-filestream@0.0.7':
     dependencies:
       long-timeout: 0.1.1
@@ -7614,6 +7963,9 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
+  abbrev@1.1.1:
+    optional: true
+
   abort-controller@3.0.0:
     dependencies:
       event-target-shim: 5.0.1
@@ -7634,6 +7986,24 @@ snapshots:
   acorn@8.16.0: {}
 
   address@1.2.2: {}
+
+  agent-base@6.0.2:
+    dependencies:
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
+  agentkeepalive@4.6.0:
+    dependencies:
+      humanize-ms: 1.2.1
+    optional: true
+
+  aggregate-error@3.1.0:
+    dependencies:
+      clean-stack: 2.2.0
+      indent-string: 4.0.0
+    optional: true
 
   ajv@6.14.0:
     dependencies:
@@ -7677,6 +8047,9 @@ snapshots:
 
   append-field@1.0.0: {}
 
+  aproba@2.1.0:
+    optional: true
+
   archiver-utils@5.0.2:
     dependencies:
       glob: 10.5.0
@@ -7700,6 +8073,12 @@ snapshots:
       - bare-abort-controller
       - bare-buffer
       - react-native-b4a
+
+  are-we-there-yet@3.0.1:
+    dependencies:
+      delegates: 1.0.0
+      readable-stream: 3.6.2
+    optional: true
 
   arg@4.1.3: {}
 
@@ -7878,6 +8257,10 @@ snapshots:
 
   bcryptjs@3.0.3: {}
 
+  bindings@1.5.0:
+    dependencies:
+      file-uri-to-path: 1.0.0
+
   bintrees@1.0.2: {}
 
   bl@4.1.0:
@@ -7901,6 +8284,14 @@ snapshots:
       type-is: 2.0.1
     transitivePeerDependencies:
       - supports-color
+
+  bookshelf@1.2.0(knex@3.2.9(sqlite3@5.1.7)):
+    dependencies:
+      bluebird: 3.7.2
+      create-error: 0.3.1
+      inflection: 1.13.4
+      knex: 3.2.9(sqlite3@5.1.7)
+      lodash: 4.18.1
 
   bowser@2.14.1: {}
 
@@ -7978,6 +8369,30 @@ snapshots:
 
   bytes@3.1.2: {}
 
+  cacache@15.3.0:
+    dependencies:
+      '@npmcli/fs': 1.1.1
+      '@npmcli/move-file': 1.1.2
+      chownr: 2.0.0
+      fs-minipass: 2.1.0
+      glob: 7.2.3
+      infer-owner: 1.0.4
+      lru-cache: 6.0.0
+      minipass: 3.3.6
+      minipass-collect: 1.0.2
+      minipass-flush: 1.0.7
+      minipass-pipeline: 1.2.4
+      mkdirp: 1.0.4
+      p-map: 4.0.0
+      promise-inflight: 1.0.1
+      rimraf: 3.0.2
+      ssri: 8.0.1
+      tar: 6.2.1
+      unique-filename: 1.1.1
+    transitivePeerDependencies:
+      - bluebird
+    optional: true
+
   cacheable-lookup@7.0.0: {}
 
   cacheable-request@13.0.18:
@@ -8021,7 +8436,14 @@ snapshots:
 
   chalk@5.6.2: {}
 
+  chownr@1.1.4: {}
+
+  chownr@2.0.0: {}
+
   ci-info@4.4.0: {}
+
+  clean-stack@2.2.0:
+    optional: true
 
   cli-cursor@3.1.0:
     dependencies:
@@ -8048,6 +8470,9 @@ snapshots:
       color-name: 1.1.4
 
   color-name@1.1.4: {}
+
+  color-support@1.1.3:
+    optional: true
 
   colorette@2.0.19: {}
 
@@ -8102,6 +8527,9 @@ snapshots:
       readable-stream: 3.6.2
       typedarray: 0.0.6
 
+  console-control-strings@1.1.0:
+    optional: true
+
   consolidate@0.15.1(lodash@4.18.1):
     dependencies:
       bluebird: 3.7.2
@@ -8142,6 +8570,8 @@ snapshots:
     dependencies:
       crc-32: 1.2.2
       readable-stream: 4.7.0
+
+  create-error@0.3.1: {}
 
   create-require@1.1.1: {}
 
@@ -8185,6 +8615,12 @@ snapshots:
     dependencies:
       mimic-response: 4.0.0
 
+  decompress-response@6.0.0:
+    dependencies:
+      mimic-response: 3.1.0
+
+  deep-extend@0.6.0: {}
+
   deep-is@0.1.4: {}
 
   defaults@1.0.4:
@@ -8194,6 +8630,9 @@ snapshots:
   define-lazy-prop@2.0.0: {}
 
   delayed-stream@1.0.0: {}
+
+  delegates@1.0.0:
+    optional: true
 
   depd@2.0.0: {}
 
@@ -8246,6 +8685,11 @@ snapshots:
 
   encodeurl@2.0.0: {}
 
+  encoding@0.1.13:
+    dependencies:
+      iconv-lite: 0.6.3
+    optional: true
+
   end-of-stream@1.4.5:
     dependencies:
       once: 1.4.0
@@ -8253,6 +8697,12 @@ snapshots:
   enquirer@2.3.6:
     dependencies:
       ansi-colors: 4.1.3
+
+  env-paths@2.2.1:
+    optional: true
+
+  err-code@2.0.3:
+    optional: true
 
   error-ex@1.3.4:
     dependencies:
@@ -8400,6 +8850,8 @@ snapshots:
 
   events@3.3.0: {}
 
+  expand-template@2.0.3: {}
+
   expect-type@1.3.0: {}
 
   expect@30.3.0:
@@ -8511,6 +8963,8 @@ snapshots:
     dependencies:
       flat-cache: 4.0.1
 
+  file-uri-to-path@1.0.0: {}
+
   finalhandler@2.1.1:
     dependencies:
       debug: 4.4.3
@@ -8593,12 +9047,28 @@ snapshots:
       jsonfile: 6.2.1
       universalify: 2.0.1
 
+  fs-minipass@2.1.0:
+    dependencies:
+      minipass: 3.3.6
+
   fs.realpath@1.0.0: {}
 
   fsevents@2.3.3:
     optional: true
 
   function-bind@1.1.2: {}
+
+  gauge@4.0.4:
+    dependencies:
+      aproba: 2.1.0
+      color-support: 1.1.3
+      console-control-strings: 1.1.0
+      has-unicode: 2.0.1
+      signal-exit: 3.0.7
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wide-align: 1.1.5
+    optional: true
 
   gelf-stream@1.1.1:
     dependencies:
@@ -8640,6 +9110,8 @@ snapshots:
       is-stream: 4.0.1
 
   getopts@2.3.0: {}
+
+  github-from-package@0.0.0: {}
 
   glob-parent@6.0.2:
     dependencies:
@@ -8701,6 +9173,9 @@ snapshots:
     dependencies:
       has-symbols: 1.1.0
 
+  has-unicode@2.0.1:
+    optional: true
+
   hasown@2.0.3:
     dependencies:
       function-bind: 1.1.2
@@ -8719,14 +9194,41 @@ snapshots:
       statuses: 2.0.2
       toidentifier: 1.0.1
 
+  http-proxy-agent@4.0.1:
+    dependencies:
+      '@tootallnate/once': 1.1.2
+      agent-base: 6.0.2
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
   http2-wrapper@2.2.1:
     dependencies:
       quick-lru: 5.1.1
       resolve-alpn: 1.2.1
 
+  https-proxy-agent@5.0.1:
+    dependencies:
+      agent-base: 6.0.2
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
   human-interval@2.0.1:
     dependencies:
       numbered: 1.1.0
+
+  humanize-ms@1.2.1:
+    dependencies:
+      ms: 2.1.3
+    optional: true
+
+  iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
+    optional: true
 
   iconv-lite@0.7.2:
     dependencies:
@@ -8745,6 +9247,14 @@ snapshots:
 
   imurmurhash@0.1.4: {}
 
+  indent-string@4.0.0:
+    optional: true
+
+  infer-owner@1.0.4:
+    optional: true
+
+  inflection@1.13.4: {}
+
   inflight@1.0.6:
     dependencies:
       once: 1.4.0
@@ -8752,9 +9262,14 @@ snapshots:
 
   inherits@2.0.4: {}
 
+  ini@1.3.8: {}
+
   ini@2.0.0: {}
 
   interpret@2.2.0: {}
+
+  ip-address@10.1.0:
+    optional: true
 
   ipaddr.js@1.9.1: {}
 
@@ -8785,6 +9300,9 @@ snapshots:
   is-invalid-path@0.1.0:
     dependencies:
       is-glob: 2.0.1
+
+  is-lambda@1.0.1:
+    optional: true
 
   is-node-process@1.2.0: {}
 
@@ -8970,7 +9488,7 @@ snapshots:
     dependencies:
       '@keyv/serialize': 1.1.1
 
-  knex@3.2.9:
+  knex@3.2.9(sqlite3@5.1.7):
     dependencies:
       colorette: 2.0.19
       commander: 10.0.1
@@ -8986,6 +9504,8 @@ snapshots:
       resolve-from: 5.0.0
       tarn: 3.0.2
       tildify: 2.0.0
+    optionalDependencies:
+      sqlite3: 5.1.7
     transitivePeerDependencies:
       - supports-color
 
@@ -9106,6 +9626,11 @@ snapshots:
     dependencies:
       yallist: 3.1.1
 
+  lru-cache@6.0.0:
+    dependencies:
+      yallist: 4.0.0
+    optional: true
+
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -9129,6 +9654,29 @@ snapshots:
       semver: 7.7.4
 
   make-error@1.3.6: {}
+
+  make-fetch-happen@9.1.0:
+    dependencies:
+      agentkeepalive: 4.6.0
+      cacache: 15.3.0
+      http-cache-semantics: 4.2.0
+      http-proxy-agent: 4.0.1
+      https-proxy-agent: 5.0.1
+      is-lambda: 1.0.1
+      lru-cache: 6.0.0
+      minipass: 3.3.6
+      minipass-collect: 1.0.2
+      minipass-fetch: 1.4.1
+      minipass-flush: 1.0.7
+      minipass-pipeline: 1.2.4
+      negotiator: 0.6.4
+      promise-retry: 2.0.1
+      socks-proxy-agent: 6.2.1
+      ssri: 8.0.1
+    transitivePeerDependencies:
+      - bluebird
+      - supports-color
+    optional: true
 
   makeerror@1.0.12:
     dependencies:
@@ -9162,6 +9710,8 @@ snapshots:
 
   mimic-fn@2.1.0: {}
 
+  mimic-response@3.1.0: {}
+
   mimic-response@4.0.0: {}
 
   mingo@2.5.3: {}
@@ -9188,12 +9738,56 @@ snapshots:
 
   minimist@1.2.8: {}
 
+  minipass-collect@1.0.2:
+    dependencies:
+      minipass: 3.3.6
+    optional: true
+
+  minipass-fetch@1.4.1:
+    dependencies:
+      minipass: 3.3.6
+      minipass-sized: 1.0.3
+      minizlib: 2.1.2
+    optionalDependencies:
+      encoding: 0.1.13
+    optional: true
+
+  minipass-flush@1.0.7:
+    dependencies:
+      minipass: 3.3.6
+    optional: true
+
+  minipass-pipeline@1.2.4:
+    dependencies:
+      minipass: 3.3.6
+    optional: true
+
+  minipass-sized@1.0.3:
+    dependencies:
+      minipass: 3.3.6
+    optional: true
+
+  minipass@3.3.6:
+    dependencies:
+      yallist: 4.0.0
+
+  minipass@5.0.0: {}
+
   minipass@7.1.3: {}
+
+  minizlib@2.1.2:
+    dependencies:
+      minipass: 3.3.6
+      yallist: 4.0.0
+
+  mkdirp-classic@0.5.3: {}
 
   mkdirp@0.5.6:
     dependencies:
       minimist: 1.2.8
     optional: true
+
+  mkdirp@1.0.4: {}
 
   moment-timezone@0.5.48:
     dependencies:
@@ -9228,6 +9822,8 @@ snapshots:
 
   nanoid@3.3.11: {}
 
+  napi-build-utils@2.0.0: {}
+
   natural-compare@1.4.0: {}
 
   nconf@0.13.0:
@@ -9240,6 +9836,9 @@ snapshots:
   ncp@2.0.0:
     optional: true
 
+  negotiator@0.6.4:
+    optional: true
+
   negotiator@1.0.0: {}
 
   nock@14.0.12:
@@ -9247,6 +9846,29 @@ snapshots:
       '@mswjs/interceptors': 0.41.4
       json-stringify-safe: 5.0.1
       propagate: 2.0.1
+
+  node-abi@3.89.0:
+    dependencies:
+      semver: 7.7.4
+
+  node-addon-api@7.1.1: {}
+
+  node-gyp@8.4.1:
+    dependencies:
+      env-paths: 2.2.1
+      glob: 7.2.3
+      graceful-fs: 4.2.11
+      make-fetch-happen: 9.1.0
+      nopt: 5.0.0
+      npmlog: 6.0.2
+      rimraf: 3.0.2
+      semver: 7.7.4
+      tar: 6.2.1
+      which: 2.0.2
+    transitivePeerDependencies:
+      - bluebird
+      - supports-color
+    optional: true
 
   node-int64@0.4.0: {}
 
@@ -9325,6 +9947,11 @@ snapshots:
 
   nodemailer@8.0.5: {}
 
+  nopt@5.0.0:
+    dependencies:
+      abbrev: 1.1.1
+    optional: true
+
   normalize-path@3.0.0: {}
 
   normalize-url@8.1.1: {}
@@ -9332,6 +9959,14 @@ snapshots:
   npm-run-path@4.0.1:
     dependencies:
       path-key: 3.1.1
+
+  npmlog@6.0.2:
+    dependencies:
+      are-we-there-yet: 3.0.1
+      console-control-strings: 1.1.0
+      gauge: 4.0.4
+      set-blocking: 2.0.0
+    optional: true
 
   numbered@1.1.0: {}
 
@@ -9499,6 +10134,11 @@ snapshots:
     dependencies:
       p-limit: 3.1.0
 
+  p-map@4.0.0:
+    dependencies:
+      aggregate-error: 3.1.0
+    optional: true
+
   p-timeout@3.2.0:
     dependencies:
       p-finally: 1.0.0
@@ -9565,6 +10205,21 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  prebuild-install@7.1.3:
+    dependencies:
+      detect-libc: 2.1.2
+      expand-template: 2.0.3
+      github-from-package: 0.0.0
+      minimist: 1.2.8
+      mkdirp-classic: 0.5.3
+      napi-build-utils: 2.0.0
+      node-abi: 3.89.0
+      pump: 3.0.4
+      rc: 1.2.8
+      simple-get: 4.0.1
+      tar-fs: 2.1.4
+      tunnel-agent: 0.6.0
+
   prelude-ls@1.2.1: {}
 
   pretty-format@30.3.0:
@@ -9586,6 +10241,15 @@ snapshots:
     dependencies:
       '@opentelemetry/api': 1.9.1
       tdigest: 0.1.2
+
+  promise-inflight@1.0.1:
+    optional: true
+
+  promise-retry@2.0.1:
+    dependencies:
+      err-code: 2.0.3
+      retry: 0.12.0
+    optional: true
 
   propagate@2.0.1: {}
 
@@ -9623,6 +10287,13 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.7.2
       unpipe: 1.0.0
+
+  rc@1.2.8:
+    dependencies:
+      deep-extend: 0.6.0
+      ini: 1.3.8
+      minimist: 1.2.8
+      strip-json-comments: 2.0.1
 
   react-is@18.3.1: {}
 
@@ -9705,6 +10376,9 @@ snapshots:
       onetime: 5.1.2
       signal-exit: 3.0.7
 
+  retry@0.12.0:
+    optional: true
+
   reusify@1.1.0: {}
 
   rewire@9.0.1:
@@ -9718,6 +10392,11 @@ snapshots:
   rimraf@2.4.5:
     dependencies:
       glob: 6.0.4
+    optional: true
+
+  rimraf@3.0.2:
+    dependencies:
+      glob: 7.2.3
     optional: true
 
   rolldown@1.0.0-rc.16:
@@ -9795,6 +10474,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  set-blocking@2.0.0:
+    optional: true
+
   setprototypeof@1.2.0: {}
 
   shebang-command@2.0.0:
@@ -9837,6 +10519,14 @@ snapshots:
 
   signal-exit@4.1.0: {}
 
+  simple-concat@1.0.1: {}
+
+  simple-get@4.0.1:
+    dependencies:
+      decompress-response: 6.0.0
+      once: 1.4.0
+      simple-concat: 1.0.1
+
   sinon@21.1.2:
     dependencies:
       '@sinonjs/commons': 3.0.1
@@ -9846,7 +10536,25 @@ snapshots:
 
   slash@3.0.0: {}
 
+  smart-buffer@4.2.0:
+    optional: true
+
   smol-toml@1.6.1: {}
+
+  socks-proxy-agent@6.2.1:
+    dependencies:
+      agent-base: 6.0.2
+      debug: 4.4.3
+      socks: 2.8.7
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
+  socks@2.8.7:
+    dependencies:
+      ip-address: 10.1.0
+      smart-buffer: 4.2.0
+    optional: true
 
   source-map-js@1.2.1: {}
 
@@ -9860,6 +10568,23 @@ snapshots:
   split2@4.2.0: {}
 
   sprintf-js@1.0.3: {}
+
+  sqlite3@5.1.7:
+    dependencies:
+      bindings: 1.5.0
+      node-addon-api: 7.1.1
+      prebuild-install: 7.1.3
+      tar: 6.2.1
+    optionalDependencies:
+      node-gyp: 8.4.1
+    transitivePeerDependencies:
+      - bluebird
+      - supports-color
+
+  ssri@8.0.1:
+    dependencies:
+      minipass: 3.3.6
+    optional: true
 
   stack-utils@2.0.6:
     dependencies:
@@ -9916,6 +10641,8 @@ snapshots:
 
   strip-bom@3.0.0: {}
 
+  strip-json-comments@2.0.1: {}
+
   strip-json-comments@3.1.1: {}
 
   strnum@2.2.3: {}
@@ -9963,6 +10690,13 @@ snapshots:
       array-back: 6.2.3
       wordwrapjs: 5.1.1
 
+  tar-fs@2.1.4:
+    dependencies:
+      chownr: 1.1.4
+      mkdirp-classic: 0.5.3
+      pump: 3.0.4
+      tar-stream: 2.2.0
+
   tar-stream@2.2.0:
     dependencies:
       bl: 4.1.0
@@ -9981,6 +10715,15 @@ snapshots:
       - bare-abort-controller
       - bare-buffer
       - react-native-b4a
+
+  tar@6.2.1:
+    dependencies:
+      chownr: 2.0.0
+      fs-minipass: 2.1.0
+      minipass: 5.0.0
+      minizlib: 2.1.2
+      mkdirp: 1.0.4
+      yallist: 4.0.0
 
   tarn@3.0.2: {}
 
@@ -10078,6 +10821,10 @@ snapshots:
 
   tslib@2.8.1: {}
 
+  tunnel-agent@0.6.0:
+    dependencies:
+      safe-buffer: 5.2.1
+
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
@@ -10129,6 +10876,16 @@ snapshots:
   unicode-property-aliases-ecmascript@2.2.0: {}
 
   unidecode@1.1.0: {}
+
+  unique-filename@1.1.1:
+    dependencies:
+      unique-slug: 2.0.2
+    optional: true
+
+  unique-slug@2.0.2:
+    dependencies:
+      imurmurhash: 0.1.4
+    optional: true
 
   universalify@2.0.1: {}
 
@@ -10215,6 +10972,11 @@ snapshots:
       siginfo: 2.0.0
       stackback: 0.0.2
 
+  wide-align@1.1.5:
+    dependencies:
+      string-width: 4.2.3
+    optional: true
+
   word-wrap@1.2.5: {}
 
   wordwrapjs@5.1.1: {}
@@ -10243,6 +11005,8 @@ snapshots:
   y18n@5.0.8: {}
 
   yallist@3.1.1: {}
+
+  yallist@4.0.0: {}
 
   yaml@1.10.3: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,6 +6,7 @@ onlyBuiltDependencies:
   - dtrace-provider
   - esbuild
   - nx
+  - sqlite3
 catalog:
   sinon: 21.1.2
   ts-node: 10.9.2


### PR DESCRIPTION
## Summary
- `hasMultiTableSource` matched `/\bjoin\b/i` against the fully compiled SQL, so a `where id in (select … inner join …)` forced `count(distinct posts.id)` even when the outer query was still single-table. On a 267k-post Ghost site filtered by author this was a measured ~20% regression on the count aggregate (316ms vs 257ms) for zero correctness benefit — the weedout step already guaranteed distinct rows.
- Switched detection to walk knex's query-builder AST (`_statements` + `_single.table`) instead of regex-matching compiled SQL. Joins, unions, derived tables and comma-separated FROM lists are all read as structured data, and JOINs nested in `WHERE id IN (…)` subqueries live under a `where` grouping and are correctly ignored.
- Since bookshelf is built on knex, the builder always exposes `_statements` / `_single` — no SQL fallback needed. The whole check collapses to a ~30-line AST walk: no regexes, no `toSQL()` call, no paren-stripping, no derived helpers.

## Tests
Added `bookshelf@1.2.0`, `knex@3.2.9` and `sqlite3@5.1.7` as devDependencies so the plugin can be tested against real knex/bookshelf instances instead of hand-rolled stubs. 25 tests total, 100% line/branch/function coverage on `lib/bookshelf-pagination.js`.

- **14 stub tests** (`test/pagination.test.js`) — pagination metadata math, `limit='all'`, `transacting` passthrough, error wrapping (NotFound / BadRequest / unknown), and the `parseOptions` / `formatResponse` utilities. None of these need a real DB.
- **9 direct `hasMultiTableSource` tests** (`test/pagination-integration.test.js`) — call the function against real knex QueryBuilders (no DB connection) and cover every branch: plain single-table, subquery-in-WHERE, innerJoin, leftJoin/joinRaw, UNION, derived table in FROM, `fromRaw` with multiple tables, comma-string table, and CTE-only. These pin the plugin's assumptions about knex's AST shape to the version of knex actually installed, and cover edge cases that can't be driven through `fetchPage` end-to-end (UNION + aggregate is semantically weird; a comma-string table fails at sqlite execution).
- **2 end-to-end `fetchPage` tests** — the only two scenarios that carry unique weight on top of the direct suite:
  1. An inner join that duplicates rows (p1 × two tags → 3 physical rows for 2 published posts). This is the only shape where `count(*)` and `count(distinct)` actually produce different totals, so it's the only test that catches a "we picked the wrong aggregate" bug at the result level.
  2. A subquery JOIN in WHERE — the named regression this PR is about, kept as an explicit end-to-end guard that the fix reaches production via `fetchPage`.

Each e2e test listens on knex's `query` event to assert *which* count aggregate the plugin chose, and asserts `pagination.total` against a value that's only correct if that aggregate was picked — so "we picked count(*)" and "the result is right" are verified together.

## Notes on upstream consumers
This is strictly safe for anyone already using `useSmartCount: true`: every case the old code flagged as multi-table is still flagged by the AST walk. The change only *removes* false positives (subquery JOINs) and *adds* one previously-missed case (derived tables in FROM). `useBasicCount` and the default distinct-count behaviour are untouched.