### PR TITLE
Move pnpm config to workspace.yaml, catalog shared devDeps

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,18 +29,8 @@
     "nx": "22.6.5",
     "oxfmt": "0.45.0",
     "oxlint": "1.60.0",
-    "sinon": "21.1.2",
-    "ts-node": "10.9.2",
+    "sinon": "catalog:",
+    "ts-node": "catalog:",
     "vitest": "4.1.4"
-  },
-  "pnpm": {
-    "overrides": {
-      "node-loggly-bulk": "^4.0.2"
-    },
-    "onlyBuiltDependencies": [
-      "dtrace-provider",
-      "esbuild",
-      "nx"
-    ]
   }
 }

--- a/packages/api-framework/package.json
+++ b/packages/api-framework/package.json
@@ -30,6 +30,6 @@
     "lodash": "4.18.1"
   },
   "devDependencies": {
-    "sinon": "21.1.2"
+    "sinon": "catalog:"
   }
 }

--- a/packages/bookshelf-collision/package.json
+++ b/packages/bookshelf-collision/package.json
@@ -28,6 +28,6 @@
     "moment-timezone": "^0.5.33"
   },
   "devDependencies": {
-    "sinon": "21.1.2"
+    "sinon": "catalog:"
   }
 }

--- a/packages/bookshelf-custom-query/package.json
+++ b/packages/bookshelf-custom-query/package.json
@@ -23,6 +23,6 @@
     "posttest": "pnpm run lint"
   },
   "devDependencies": {
-    "sinon": "21.1.2"
+    "sinon": "catalog:"
   }
 }

--- a/packages/bookshelf-eager-load/package.json
+++ b/packages/bookshelf-eager-load/package.json
@@ -27,6 +27,6 @@
     "lodash": "4.18.1"
   },
   "devDependencies": {
-    "sinon": "21.1.2"
+    "sinon": "catalog:"
   }
 }

--- a/packages/bookshelf-filter/package.json
+++ b/packages/bookshelf-filter/package.json
@@ -29,6 +29,6 @@
     "@tryghost/tpl": "workspace:*"
   },
   "devDependencies": {
-    "sinon": "21.1.2"
+    "sinon": "catalog:"
   }
 }

--- a/packages/bookshelf-has-posts/package.json
+++ b/packages/bookshelf-has-posts/package.json
@@ -27,6 +27,6 @@
     "lodash": "4.18.1"
   },
   "devDependencies": {
-    "sinon": "21.1.2"
+    "sinon": "catalog:"
   }
 }

--- a/packages/bookshelf-include-count/package.json
+++ b/packages/bookshelf-include-count/package.json
@@ -27,6 +27,6 @@
     "lodash": "4.18.1"
   },
   "devDependencies": {
-    "sinon": "21.1.2"
+    "sinon": "catalog:"
   }
 }

--- a/packages/bookshelf-order/package.json
+++ b/packages/bookshelf-order/package.json
@@ -26,6 +26,6 @@
     "lodash": "4.18.1"
   },
   "devDependencies": {
-    "sinon": "21.1.2"
+    "sinon": "catalog:"
   }
 }

--- a/packages/bookshelf-pagination/package.json
+++ b/packages/bookshelf-pagination/package.json
@@ -28,6 +28,6 @@
     "lodash": "4.18.1"
   },
   "devDependencies": {
-    "sinon": "21.1.2"
+    "sinon": "catalog:"
   }
 }

--- a/packages/bookshelf-plugins/package.json
+++ b/packages/bookshelf-plugins/package.json
@@ -35,6 +35,6 @@
     "@tryghost/bookshelf-transaction-events": "workspace:*"
   },
   "devDependencies": {
-    "sinon": "21.1.2"
+    "sinon": "catalog:"
   }
 }

--- a/packages/bookshelf-search/package.json
+++ b/packages/bookshelf-search/package.json
@@ -23,6 +23,6 @@
     "posttest": "pnpm run lint"
   },
   "devDependencies": {
-    "sinon": "21.1.2"
+    "sinon": "catalog:"
   }
 }

--- a/packages/bookshelf-transaction-events/package.json
+++ b/packages/bookshelf-transaction-events/package.json
@@ -23,6 +23,6 @@
     "posttest": "pnpm run lint"
   },
   "devDependencies": {
-    "sinon": "21.1.2"
+    "sinon": "catalog:"
   }
 }

--- a/packages/elasticsearch/package.json
+++ b/packages/elasticsearch/package.json
@@ -28,6 +28,6 @@
     "split2": "4.2.0"
   },
   "devDependencies": {
-    "sinon": "21.1.2"
+    "sinon": "catalog:"
   }
 }

--- a/packages/email-mock-receiver/package.json
+++ b/packages/email-mock-receiver/package.json
@@ -23,6 +23,6 @@
     "lint": "oxlint -c ../../.oxlintrc.json ."
   },
   "devDependencies": {
-    "sinon": "21.1.2"
+    "sinon": "catalog:"
   }
 }

--- a/packages/errors/package.json
+++ b/packages/errors/package.json
@@ -40,7 +40,7 @@
     "@types/node": "^22.10.0",
     "esbuild": "0.28.0",
     "lodash": "4.18.1",
-    "ts-node": "10.9.2",
-    "typescript": "5.9.3"
+    "ts-node": "catalog:",
+    "typescript": "catalog:"
   }
 }

--- a/packages/express-test/package.json
+++ b/packages/express-test/package.json
@@ -32,7 +32,7 @@
     "express": "5.2.1",
     "express-session": "1.19.0",
     "multer": "2.1.1",
-    "sinon": "21.1.2"
+    "sinon": "catalog:"
   },
   "peerDependencies": {
     "express": "^4.0.0 || ^5.0.0"

--- a/packages/http-cache-utils/package.json
+++ b/packages/http-cache-utils/package.json
@@ -23,6 +23,6 @@
     "lint": "oxlint -c ../../.oxlintrc.json ."
   },
   "devDependencies": {
-    "sinon": "21.1.2"
+    "sinon": "catalog:"
   }
 }

--- a/packages/http-stream/package.json
+++ b/packages/http-stream/package.json
@@ -28,6 +28,6 @@
   },
   "devDependencies": {
     "express": "5.2.1",
-    "sinon": "21.1.2"
+    "sinon": "catalog:"
   }
 }

--- a/packages/jest-snapshot/package.json
+++ b/packages/jest-snapshot/package.json
@@ -29,6 +29,6 @@
     "jest-snapshot": "30.3.0"
   },
   "devDependencies": {
-    "sinon": "21.1.2"
+    "sinon": "catalog:"
   }
 }

--- a/packages/job-manager/package.json
+++ b/packages/job-manager/package.json
@@ -36,6 +36,6 @@
     "@sinonjs/fake-timers": "15.3.2",
     "date-fns": "4.1.0",
     "rewire": "9.0.1",
-    "sinon": "21.1.2"
+    "sinon": "catalog:"
   }
 }

--- a/packages/logging/package.json
+++ b/packages/logging/package.json
@@ -37,6 +37,6 @@
   },
   "devDependencies": {
     "@tryghost/errors": "workspace:*",
-    "sinon": "21.1.2"
+    "sinon": "catalog:"
   }
 }

--- a/packages/metrics/package.json
+++ b/packages/metrics/package.json
@@ -30,6 +30,6 @@
   },
   "devDependencies": {
     "rewire": "9.0.1",
-    "sinon": "21.1.2"
+    "sinon": "catalog:"
   }
 }

--- a/packages/mw-error-handler/package.json
+++ b/packages/mw-error-handler/package.json
@@ -32,6 +32,6 @@
     "semver": "7.7.4"
   },
   "devDependencies": {
-    "sinon": "21.1.2"
+    "sinon": "catalog:"
   }
 }

--- a/packages/nodemailer/package.json
+++ b/packages/nodemailer/package.json
@@ -30,6 +30,6 @@
     "nodemailer-stub-transport": "1.1.0"
   },
   "devDependencies": {
-    "sinon": "21.1.2"
+    "sinon": "catalog:"
   }
 }

--- a/packages/pretty-cli/package.json
+++ b/packages/pretty-cli/package.json
@@ -28,6 +28,6 @@
     "sywac": "1.3.0"
   },
   "devDependencies": {
-    "sinon": "21.1.2"
+    "sinon": "catalog:"
   }
 }

--- a/packages/pretty-stream/package.json
+++ b/packages/pretty-stream/package.json
@@ -28,6 +28,6 @@
     "prettyjson": "1.2.5"
   },
   "devDependencies": {
-    "sinon": "21.1.2"
+    "sinon": "catalog:"
   }
 }

--- a/packages/prometheus-metrics/package.json
+++ b/packages/prometheus-metrics/package.json
@@ -40,9 +40,9 @@
     "@types/supertest": "7.2.0",
     "knex": "3.2.9",
     "nock": "14.0.12",
-    "sinon": "21.1.2",
+    "sinon": "catalog:",
     "supertest": "7.2.2",
-    "ts-node": "10.9.2",
-    "typescript": "5.9.3"
+    "ts-node": "catalog:",
+    "typescript": "catalog:"
   }
 }

--- a/packages/promise/package.json
+++ b/packages/promise/package.json
@@ -23,6 +23,6 @@
     "posttest": "pnpm run lint"
   },
   "devDependencies": {
-    "sinon": "21.1.2"
+    "sinon": "catalog:"
   }
 }

--- a/packages/request/package.json
+++ b/packages/request/package.json
@@ -33,6 +33,6 @@
   "devDependencies": {
     "nock": "14.0.12",
     "rewire": "9.0.1",
-    "sinon": "21.1.2"
+    "sinon": "catalog:"
   }
 }

--- a/packages/root-utils/package.json
+++ b/packages/root-utils/package.json
@@ -27,6 +27,6 @@
     "find-root": "1.1.0"
   },
   "devDependencies": {
-    "sinon": "21.1.2"
+    "sinon": "catalog:"
   }
 }

--- a/packages/security/package.json
+++ b/packages/security/package.json
@@ -28,7 +28,7 @@
     "bcryptjs": "3.0.3"
   },
   "devDependencies": {
-    "sinon": "21.1.2",
+    "sinon": "catalog:",
     "uuid": "13.0.0"
   }
 }

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -27,6 +27,6 @@
     "@tryghost/logging": "workspace:*"
   },
   "devDependencies": {
-    "sinon": "21.1.2"
+    "sinon": "catalog:"
   }
 }

--- a/packages/tpl/package.json
+++ b/packages/tpl/package.json
@@ -24,6 +24,6 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "sinon": "21.1.2"
+    "sinon": "catalog:"
   }
 }

--- a/packages/version/package.json
+++ b/packages/version/package.json
@@ -27,6 +27,6 @@
     "semver": "7.7.4"
   },
   "devDependencies": {
-    "sinon": "21.1.2"
+    "sinon": "catalog:"
   }
 }

--- a/packages/webhook-mock-receiver/package.json
+++ b/packages/webhook-mock-receiver/package.json
@@ -27,6 +27,6 @@
   },
   "devDependencies": {
     "got": "14.6.6",
-    "sinon": "21.1.2"
+    "sinon": "catalog:"
   }
 }

--- a/packages/zip/package.json
+++ b/packages/zip/package.json
@@ -29,6 +29,6 @@
   },
   "devDependencies": {
     "folder-hash": "4.1.2",
-    "sinon": "21.1.2"
+    "sinon": "catalog:"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,18 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+catalogs:
+  default:
+    sinon:
+      specifier: 21.1.2
+      version: 21.1.2
+    ts-node:
+      specifier: 10.9.2
+      version: 10.9.2
+    typescript:
+      specifier: 5.9.3
+      version: 5.9.3
+
 overrides:
   node-loggly-bulk: ^4.0.2
 
@@ -27,10 +39,10 @@ importers:
         specifier: 1.60.0
         version: 1.60.0
       sinon:
-        specifier: 21.1.2
+        specifier: 'catalog:'
         version: 21.1.2
       ts-node:
-        specifier: 10.9.2
+        specifier: 'catalog:'
         version: 10.9.2(@types/node@25.6.0)(typescript@5.9.3)
       vitest:
         specifier: 4.1.4
@@ -58,7 +70,7 @@ importers:
         version: 4.18.1
     devDependencies:
       sinon:
-        specifier: 21.1.2
+        specifier: 'catalog:'
         version: 21.1.2
 
   packages/bookshelf-collision:
@@ -74,13 +86,13 @@ importers:
         version: 0.5.48
     devDependencies:
       sinon:
-        specifier: 21.1.2
+        specifier: 'catalog:'
         version: 21.1.2
 
   packages/bookshelf-custom-query:
     devDependencies:
       sinon:
-        specifier: 21.1.2
+        specifier: 'catalog:'
         version: 21.1.2
 
   packages/bookshelf-eager-load:
@@ -93,7 +105,7 @@ importers:
         version: 4.18.1
     devDependencies:
       sinon:
-        specifier: 21.1.2
+        specifier: 'catalog:'
         version: 21.1.2
 
   packages/bookshelf-filter:
@@ -112,7 +124,7 @@ importers:
         version: link:../tpl
     devDependencies:
       sinon:
-        specifier: 21.1.2
+        specifier: 'catalog:'
         version: 21.1.2
 
   packages/bookshelf-has-posts:
@@ -125,7 +137,7 @@ importers:
         version: 4.18.1
     devDependencies:
       sinon:
-        specifier: 21.1.2
+        specifier: 'catalog:'
         version: 21.1.2
 
   packages/bookshelf-include-count:
@@ -138,7 +150,7 @@ importers:
         version: 4.18.1
     devDependencies:
       sinon:
-        specifier: 21.1.2
+        specifier: 'catalog:'
         version: 21.1.2
 
   packages/bookshelf-order:
@@ -148,7 +160,7 @@ importers:
         version: 4.18.1
     devDependencies:
       sinon:
-        specifier: 21.1.2
+        specifier: 'catalog:'
         version: 21.1.2
 
   packages/bookshelf-pagination:
@@ -164,7 +176,7 @@ importers:
         version: 4.18.1
     devDependencies:
       sinon:
-        specifier: 21.1.2
+        specifier: 'catalog:'
         version: 21.1.2
 
   packages/bookshelf-plugins:
@@ -201,19 +213,19 @@ importers:
         version: link:../bookshelf-transaction-events
     devDependencies:
       sinon:
-        specifier: 21.1.2
+        specifier: 'catalog:'
         version: 21.1.2
 
   packages/bookshelf-search:
     devDependencies:
       sinon:
-        specifier: 21.1.2
+        specifier: 'catalog:'
         version: 21.1.2
 
   packages/bookshelf-transaction-events:
     devDependencies:
       sinon:
-        specifier: 21.1.2
+        specifier: 'catalog:'
         version: 21.1.2
 
   packages/config:
@@ -259,13 +271,13 @@ importers:
         version: 4.2.0
     devDependencies:
       sinon:
-        specifier: 21.1.2
+        specifier: 'catalog:'
         version: 21.1.2
 
   packages/email-mock-receiver:
     devDependencies:
       sinon:
-        specifier: 21.1.2
+        specifier: 'catalog:'
         version: 21.1.2
 
   packages/errors:
@@ -283,10 +295,10 @@ importers:
         specifier: 4.18.1
         version: 4.18.1
       ts-node:
-        specifier: 10.9.2
+        specifier: 'catalog:'
         version: 10.9.2(@types/node@22.19.17)(typescript@5.9.3)
       typescript:
-        specifier: 5.9.3
+        specifier: 'catalog:'
         version: 5.9.3
 
   packages/express-test:
@@ -314,13 +326,13 @@ importers:
         specifier: 2.1.1
         version: 2.1.1
       sinon:
-        specifier: 21.1.2
+        specifier: 'catalog:'
         version: 21.1.2
 
   packages/http-cache-utils:
     devDependencies:
       sinon:
-        specifier: 21.1.2
+        specifier: 'catalog:'
         version: 21.1.2
 
   packages/http-stream:
@@ -336,7 +348,7 @@ importers:
         specifier: 5.2.1
         version: 5.2.1
       sinon:
-        specifier: 21.1.2
+        specifier: 'catalog:'
         version: 21.1.2
 
   packages/jest-snapshot:
@@ -355,7 +367,7 @@ importers:
         version: 30.3.0
     devDependencies:
       sinon:
-        specifier: 21.1.2
+        specifier: 'catalog:'
         version: 21.1.2
 
   packages/job-manager:
@@ -395,7 +407,7 @@ importers:
         specifier: 9.0.1
         version: 9.0.1
       sinon:
-        specifier: 21.1.2
+        specifier: 'catalog:'
         version: 21.1.2
 
   packages/logging:
@@ -438,7 +450,7 @@ importers:
         specifier: workspace:*
         version: link:../errors
       sinon:
-        specifier: 21.1.2
+        specifier: 'catalog:'
         version: 21.1.2
 
   packages/metrics:
@@ -460,7 +472,7 @@ importers:
         specifier: 9.0.1
         version: 9.0.1
       sinon:
-        specifier: 21.1.2
+        specifier: 'catalog:'
         version: 21.1.2
 
   packages/mw-error-handler:
@@ -485,7 +497,7 @@ importers:
         version: 7.7.4
     devDependencies:
       sinon:
-        specifier: 21.1.2
+        specifier: 'catalog:'
         version: 21.1.2
 
   packages/mw-vhost:
@@ -513,7 +525,7 @@ importers:
         version: 1.1.0
     devDependencies:
       sinon:
-        specifier: 21.1.2
+        specifier: 'catalog:'
         version: 21.1.2
 
   packages/pretty-cli:
@@ -526,7 +538,7 @@ importers:
         version: 1.3.0
     devDependencies:
       sinon:
-        specifier: 21.1.2
+        specifier: 'catalog:'
         version: 21.1.2
 
   packages/pretty-stream:
@@ -542,7 +554,7 @@ importers:
         version: 1.2.5
     devDependencies:
       sinon:
-        specifier: 21.1.2
+        specifier: 'catalog:'
         version: 21.1.2
 
   packages/prometheus-metrics:
@@ -585,22 +597,22 @@ importers:
         specifier: 14.0.12
         version: 14.0.12
       sinon:
-        specifier: 21.1.2
+        specifier: 'catalog:'
         version: 21.1.2
       supertest:
         specifier: 7.2.2
         version: 7.2.2
       ts-node:
-        specifier: 10.9.2
+        specifier: 'catalog:'
         version: 10.9.2(@types/node@22.19.17)(typescript@5.9.3)
       typescript:
-        specifier: 5.9.3
+        specifier: 'catalog:'
         version: 5.9.3
 
   packages/promise:
     devDependencies:
       sinon:
-        specifier: 21.1.2
+        specifier: 'catalog:'
         version: 21.1.2
 
   packages/request:
@@ -631,7 +643,7 @@ importers:
         specifier: 9.0.1
         version: 9.0.1
       sinon:
-        specifier: 21.1.2
+        specifier: 'catalog:'
         version: 21.1.2
 
   packages/root-utils:
@@ -644,7 +656,7 @@ importers:
         version: 1.1.0
     devDependencies:
       sinon:
-        specifier: 21.1.2
+        specifier: 'catalog:'
         version: 21.1.2
 
   packages/security:
@@ -657,7 +669,7 @@ importers:
         version: 3.0.3
     devDependencies:
       sinon:
-        specifier: 21.1.2
+        specifier: 'catalog:'
         version: 21.1.2
       uuid:
         specifier: 13.0.0
@@ -673,13 +685,13 @@ importers:
         version: link:../logging
     devDependencies:
       sinon:
-        specifier: 21.1.2
+        specifier: 'catalog:'
         version: 21.1.2
 
   packages/tpl:
     devDependencies:
       sinon:
-        specifier: 21.1.2
+        specifier: 'catalog:'
         version: 21.1.2
 
   packages/validator:
@@ -710,7 +722,7 @@ importers:
         version: 7.7.4
     devDependencies:
       sinon:
-        specifier: 21.1.2
+        specifier: 'catalog:'
         version: 21.1.2
 
   packages/webhook-mock-receiver:
@@ -723,7 +735,7 @@ importers:
         specifier: 14.6.6
         version: 14.6.6
       sinon:
-        specifier: 21.1.2
+        specifier: 'catalog:'
         version: 21.1.2
 
   packages/zip:
@@ -742,7 +754,7 @@ importers:
         specifier: 4.1.2
         version: 4.1.2
       sinon:
-        specifier: 21.1.2
+        specifier: 'catalog:'
         version: 21.1.2
 
 packages:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,12 @@
 packages:
   - 'packages/*'
+overrides:
+  node-loggly-bulk: ^4.0.2
+onlyBuiltDependencies:
+  - dtrace-provider
+  - esbuild
+  - nx
+catalog:
+  sinon: 21.1.2
+  ts-node: 10.9.2
+  typescript: 5.9.3


### PR DESCRIPTION
## Summary

Follow-up to #554. Two pnpm-10-native cleanups, zero behavior change.

- **Move `overrides` and `onlyBuiltDependencies` from root `package.json` into `pnpm-workspace.yaml`.** pnpm 10 reads these from either location, but `pnpm-workspace.yaml` is the recommended home — co-located with the `packages` glob and the new catalog (below).
- **Introduce a default `catalog:` for shared devDeps.** Three packages were pinned identically across many manifests:

  | dep        | where |
  |------------|-------|
  | `sinon`      | 35 packages + root |
  | `ts-node`    | 2 packages + root |
  | `typescript` | 2 packages |

  All references become `"catalog:"`. Bumping any of these is now a one-line change in `pnpm-workspace.yaml` instead of a 35-file PR. `typescript` and `ts-node` will spread further with the ts-esm-migration, so cataloguing them now avoids having to re-touch each manifest later.

## Publish-time behavior

`pnpm pack` rewrites `catalog:` to the real pinned version at publish time, exactly like it does for `workspace:*`. Verified locally by packing `@tryghost/api-framework`:

```json
"sinon": "21.1.2"
```

So consumers outside the monorepo are unaffected.

## Test plan

- [x] `pnpm install` regenerates the lockfile cleanly; `catalogs:` section appears in `pnpm-lock.yaml` with resolved versions
- [x] `pnpm lint` — 42/42 green
- [x] `pnpm test:ci` — 42/42 green
- [x] `pnpm pack` on a workspace member rewrites `catalog:` → real version
- [ ] CI `Test` job green on Node 22 and 24