### PR TITLE
Update package READMEs: yarn/eslint/lerna are all stale

### DIFF
--- a/packages/api-framework/README.md
+++ b/packages/api-framework/README.md
@@ -142,9 +142,9 @@ This is a monorepo package.
 Follow the instructions for the top-level repo.
 
 1. `git clone` this repo & `cd` into it as usual
-2. Run `yarn` to install top-level dependencies.
+2. Run `pnpm install` to install top-level dependencies.
 
 ## Test
 
-- `yarn lint` run just eslint
-- `yarn test` run lint and tests
+- `pnpm lint` runs oxlint
+- `pnpm test` runs lint and tests

--- a/packages/bookshelf-collision/README.md
+++ b/packages/bookshelf-collision/README.md
@@ -6,7 +6,7 @@
 
 or
 
-`yarn add @tryghost/bookshelf-collision`
+`pnpm add @tryghost/bookshelf-collision`
 
 ## Purpose
 
@@ -16,21 +16,21 @@ Bookshelf plugin that detects stale updates and throws an update-collision error
 
 ## Develop
 
-This is a mono repository, managed with [lerna](https://lernajs.io/).
+This is a mono repository, managed with [Nx](https://nx.dev).
 
 Follow the instructions for the top-level repo.
 
 1. `git clone` this repo & `cd` into it as usual
-2. Run `yarn` to install top-level dependencies.
+2. Run `pnpm install` to install top-level dependencies.
 
 ## Run
 
-- `yarn dev`
+- `pnpm dev`
 
 ## Test
 
-- `yarn lint` run just eslint
-- `yarn test` run lint and tests
+- `pnpm lint` runs oxlint
+- `pnpm test` runs lint and tests
 
 # Copyright & License
 

--- a/packages/bookshelf-custom-query/README.md
+++ b/packages/bookshelf-custom-query/README.md
@@ -6,7 +6,7 @@
 
 or
 
-`yarn add @tryghost/bookshelf-custom-query`
+`pnpm add @tryghost/bookshelf-custom-query`
 
 ## Purpose
 
@@ -16,21 +16,21 @@ Bookshelf plugin that adds reusable `customQuery` hooks to models for centralize
 
 ## Develop
 
-This is a mono repository, managed with [lerna](https://lernajs.io/).
+This is a mono repository, managed with [Nx](https://nx.dev).
 
 Follow the instructions for the top-level repo.
 
 1. `git clone` this repo & `cd` into it as usual
-2. Run `yarn` to install top-level dependencies.
+2. Run `pnpm install` to install top-level dependencies.
 
 ## Run
 
-- `yarn dev`
+- `pnpm dev`
 
 ## Test
 
-- `yarn lint` run just eslint
-- `yarn test` run lint and tests
+- `pnpm lint` runs oxlint
+- `pnpm test` runs lint and tests
 
 # Copyright & License
 

--- a/packages/bookshelf-eager-load/README.md
+++ b/packages/bookshelf-eager-load/README.md
@@ -6,7 +6,7 @@
 
 or
 
-`yarn add @tryghost/bookshelf-eager-load`
+`pnpm add @tryghost/bookshelf-eager-load`
 
 ## Purpose
 
@@ -16,21 +16,21 @@ Bookshelf plugin that applies relation joins during fetch/fetchAll for eager-loa
 
 ## Develop
 
-This is a mono repository, managed with [lerna](https://lernajs.io/).
+This is a mono repository, managed with [Nx](https://nx.dev).
 
 Follow the instructions for the top-level repo.
 
 1. `git clone` this repo & `cd` into it as usual
-2. Run `yarn` to install top-level dependencies.
+2. Run `pnpm install` to install top-level dependencies.
 
 ## Run
 
-- `yarn dev`
+- `pnpm dev`
 
 ## Test
 
-- `yarn lint` run just eslint
-- `yarn test` run lint and tests
+- `pnpm lint` runs oxlint
+- `pnpm test` runs lint and tests
 
 # Copyright & License
 

--- a/packages/bookshelf-filter/README.md
+++ b/packages/bookshelf-filter/README.md
@@ -6,7 +6,7 @@
 
 or
 
-`yarn add @tryghost/bookshelf-filter`
+`pnpm add @tryghost/bookshelf-filter`
 
 ## Purpose
 
@@ -16,21 +16,21 @@ Bookshelf plugin that parses and applies NQL filter expressions with support for
 
 ## Develop
 
-This is a mono repository, managed with [lerna](https://lernajs.io/).
+This is a mono repository, managed with [Nx](https://nx.dev).
 
 Follow the instructions for the top-level repo.
 
 1. `git clone` this repo & `cd` into it as usual
-2. Run `yarn` to install top-level dependencies.
+2. Run `pnpm install` to install top-level dependencies.
 
 ## Run
 
-- `yarn dev`
+- `pnpm dev`
 
 ## Test
 
-- `yarn lint` run just eslint
-- `yarn test` run lint and tests
+- `pnpm lint` runs oxlint
+- `pnpm test` runs lint and tests
 
 # Copyright & License
 

--- a/packages/bookshelf-has-posts/README.md
+++ b/packages/bookshelf-has-posts/README.md
@@ -6,7 +6,7 @@
 
 or
 
-`yarn add @tryghost/bookshelf-has-posts`
+`pnpm add @tryghost/bookshelf-has-posts`
 
 ## Purpose
 
@@ -16,21 +16,21 @@ Bookshelf plugin that restricts model queries to records associated with publish
 
 ## Develop
 
-This is a mono repository, managed with [lerna](https://lernajs.io/).
+This is a mono repository, managed with [Nx](https://nx.dev).
 
 Follow the instructions for the top-level repo.
 
 1. `git clone` this repo & `cd` into it as usual
-2. Run `yarn` to install top-level dependencies.
+2. Run `pnpm install` to install top-level dependencies.
 
 ## Run
 
-- `yarn dev`
+- `pnpm dev`
 
 ## Test
 
-- `yarn lint` run just eslint
-- `yarn test` run lint and tests
+- `pnpm lint` runs oxlint
+- `pnpm test` runs lint and tests
 
 # Copyright & License
 

--- a/packages/bookshelf-include-count/README.md
+++ b/packages/bookshelf-include-count/README.md
@@ -6,7 +6,7 @@
 
 or
 
-`yarn add @tryghost/bookshelf-include-count`
+`pnpm add @tryghost/bookshelf-include-count`
 
 ## Purpose
 
@@ -16,21 +16,21 @@ Bookshelf plugin that augments fetch results with relation counts requested thro
 
 ## Develop
 
-This is a mono repository, managed with [lerna](https://lernajs.io/).
+This is a mono repository, managed with [Nx](https://nx.dev).
 
 Follow the instructions for the top-level repo.
 
 1. `git clone` this repo & `cd` into it as usual
-2. Run `yarn` to install top-level dependencies.
+2. Run `pnpm install` to install top-level dependencies.
 
 ## Run
 
-- `yarn dev`
+- `pnpm dev`
 
 ## Test
 
-- `yarn lint` run just eslint
-- `yarn test` run lint and tests
+- `pnpm lint` runs oxlint
+- `pnpm test` runs lint and tests
 
 # Copyright & License
 

--- a/packages/bookshelf-order/README.md
+++ b/packages/bookshelf-order/README.md
@@ -6,7 +6,7 @@
 
 or
 
-`yarn add @tryghost/bookshelf-order`
+`pnpm add @tryghost/bookshelf-order`
 
 ## Purpose
 
@@ -16,21 +16,21 @@ Bookshelf plugin that adds standardized ordering helpers to model queries.
 
 ## Develop
 
-This is a mono repository, managed with [lerna](https://lernajs.io/).
+This is a mono repository, managed with [Nx](https://nx.dev).
 
 Follow the instructions for the top-level repo.
 
 1. `git clone` this repo & `cd` into it as usual
-2. Run `yarn` to install top-level dependencies.
+2. Run `pnpm install` to install top-level dependencies.
 
 ## Run
 
-- `yarn dev`
+- `pnpm dev`
 
 ## Test
 
-- `yarn lint` run just eslint
-- `yarn test` run lint and tests
+- `pnpm lint` runs oxlint
+- `pnpm test` runs lint and tests
 
 # Copyright & License
 

--- a/packages/bookshelf-pagination/README.md
+++ b/packages/bookshelf-pagination/README.md
@@ -6,7 +6,7 @@
 
 or
 
-`yarn add @tryghost/bookshelf-pagination`
+`pnpm add @tryghost/bookshelf-pagination`
 
 ## Purpose
 
@@ -16,21 +16,21 @@ Bookshelf plugin that adds pagination behavior and metadata to model collection 
 
 ## Develop
 
-This is a mono repository, managed with [lerna](https://lernajs.io/).
+This is a mono repository, managed with [Nx](https://nx.dev).
 
 Follow the instructions for the top-level repo.
 
 1. `git clone` this repo & `cd` into it as usual
-2. Run `yarn` to install top-level dependencies.
+2. Run `pnpm install` to install top-level dependencies.
 
 ## Run
 
-- `yarn dev`
+- `pnpm dev`
 
 ## Test
 
-- `yarn lint` run just eslint
-- `yarn test` run lint and tests
+- `pnpm lint` runs oxlint
+- `pnpm test` runs lint and tests
 
 # Copyright & License
 

--- a/packages/bookshelf-plugins/README.md
+++ b/packages/bookshelf-plugins/README.md
@@ -6,7 +6,7 @@
 
 or
 
-`yarn add @tryghost/bookshelf-plugins`
+`pnpm add @tryghost/bookshelf-plugins`
 
 ## Purpose
 
@@ -16,21 +16,21 @@ Convenience package that composes and exposes Ghost's Bookshelf plugin set in on
 
 ## Develop
 
-This is a mono repository, managed with [lerna](https://lernajs.io/).
+This is a mono repository, managed with [Nx](https://nx.dev).
 
 Follow the instructions for the top-level repo.
 
 1. `git clone` this repo & `cd` into it as usual
-2. Run `yarn` to install top-level dependencies.
+2. Run `pnpm install` to install top-level dependencies.
 
 ## Run
 
-- `yarn dev`
+- `pnpm dev`
 
 ## Test
 
-- `yarn lint` run just eslint
-- `yarn test` run lint and tests
+- `pnpm lint` runs oxlint
+- `pnpm test` runs lint and tests
 
 # Copyright & License
 

--- a/packages/bookshelf-search/README.md
+++ b/packages/bookshelf-search/README.md
@@ -6,7 +6,7 @@
 
 or
 
-`yarn add @tryghost/bookshelf-search`
+`pnpm add @tryghost/bookshelf-search`
 
 ## Purpose
 
@@ -16,21 +16,21 @@ Bookshelf plugin that adds search query helpers for text-based filtering across 
 
 ## Develop
 
-This is a mono repository, managed with [lerna](https://lernajs.io/).
+This is a mono repository, managed with [Nx](https://nx.dev).
 
 Follow the instructions for the top-level repo.
 
 1. `git clone` this repo & `cd` into it as usual
-2. Run `yarn` to install top-level dependencies.
+2. Run `pnpm install` to install top-level dependencies.
 
 ## Run
 
-- `yarn dev`
+- `pnpm dev`
 
 ## Test
 
-- `yarn lint` run just eslint
-- `yarn test` run lint and tests
+- `pnpm lint` runs oxlint
+- `pnpm test` runs lint and tests
 
 # Copyright & License
 

--- a/packages/bookshelf-transaction-events/README.md
+++ b/packages/bookshelf-transaction-events/README.md
@@ -6,7 +6,7 @@
 
 or
 
-`yarn add @tryghost/bookshelf-transaction-events`
+`pnpm add @tryghost/bookshelf-transaction-events`
 
 ## Purpose
 
@@ -16,21 +16,21 @@ Bookshelf plugin that emits lifecycle events scoped to database transaction boun
 
 ## Develop
 
-This is a mono repository, managed with [lerna](https://lernajs.io/).
+This is a mono repository, managed with [Nx](https://nx.dev).
 
 Follow the instructions for the top-level repo.
 
 1. `git clone` this repo & `cd` into it as usual
-2. Run `yarn` to install top-level dependencies.
+2. Run `pnpm install` to install top-level dependencies.
 
 ## Run
 
-- `yarn dev`
+- `pnpm dev`
 
 ## Test
 
-- `yarn lint` run just eslint
-- `yarn test` run lint and tests
+- `pnpm lint` runs oxlint
+- `pnpm test` runs lint and tests
 
 # Copyright & License
 

--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -6,7 +6,7 @@
 
 or
 
-`yarn add @tryghost/config`
+`pnpm add @tryghost/config`
 
 ## Purpose
 
@@ -16,21 +16,21 @@ Configuration loader built on `nconf` that merges env vars, argv, defaults, and 
 
 ## Develop
 
-This is a mono repository, managed with [lerna](https://lernajs.io/).
+This is a mono repository, managed with [Nx](https://nx.dev).
 
 Follow the instructions for the top-level repo.
 
 1. `git clone` this repo & `cd` into it as usual
-2. Run `yarn` to install top-level dependencies.
+2. Run `pnpm install` to install top-level dependencies.
 
 ## Run
 
-- `yarn dev`
+- `pnpm dev`
 
 ## Test
 
-- `yarn lint` run just eslint
-- `yarn test` run lint and tests
+- `pnpm lint` runs oxlint
+- `pnpm test` runs lint and tests
 
 # Copyright & License
 

--- a/packages/database-info/README.md
+++ b/packages/database-info/README.md
@@ -10,7 +10,7 @@ It currently works with SQLite, MySQL 5 & 8, and MariaDB.
 
 or
 
-`yarn add @tryghost/database-info`
+`pnpm add @tryghost/database-info`
 
 ## Purpose
 
@@ -20,21 +20,21 @@ Utility for detecting database driver, engine family, and version from a Knex co
 
 ## Develop
 
-This is a mono repository, managed with [lerna](https://lernajs.io/).
+This is a mono repository, managed with [Nx](https://nx.dev).
 
 Follow the instructions for the top-level repo.
 
 1. `git clone` this repo & `cd` into it as usual
-2. Run `yarn` to install top-level dependencies.
+2. Run `pnpm install` to install top-level dependencies.
 
 ## Run
 
-- `yarn dev`
+- `pnpm dev`
 
 ## Test
 
-- `yarn lint` run just eslint
-- `yarn test` run lint and tests
+- `pnpm lint` runs oxlint
+- `pnpm test` runs lint and tests
 
 # Copyright & License
 

--- a/packages/debug/README.md
+++ b/packages/debug/README.md
@@ -6,7 +6,7 @@
 
 or
 
-`yarn add @tryghost/debug`
+`pnpm add @tryghost/debug`
 
 ## Purpose
 
@@ -16,21 +16,21 @@ Ghost wrapper around the `debug` logger with shared namespacing conventions.
 
 ## Develop
 
-This is a mono repository, managed with [lerna](https://lernajs.io/).
+This is a mono repository, managed with [Nx](https://nx.dev).
 
 Follow the instructions for the top-level repo.
 
 1. `git clone` this repo & `cd` into it as usual
-2. Run `yarn` to install top-level dependencies.
+2. Run `pnpm install` to install top-level dependencies.
 
 ## Run
 
-- `yarn dev`
+- `pnpm dev`
 
 ## Test
 
-- `yarn lint` run just eslint
-- `yarn test` run lint and tests
+- `pnpm lint` runs oxlint
+- `pnpm test` runs lint and tests
 
 # Copyright & License
 

--- a/packages/elasticsearch/README.md
+++ b/packages/elasticsearch/README.md
@@ -6,7 +6,7 @@
 
 or
 
-`yarn add @tryghost/elasticsearch`
+`pnpm add @tryghost/elasticsearch`
 
 ## Purpose
 
@@ -16,21 +16,21 @@ Elasticsearch client wrapper plus Bunyan stream integration used by Ghost loggin
 
 ## Develop
 
-This is a mono repository, managed with [lerna](https://lernajs.io/).
+This is a mono repository, managed with [Nx](https://nx.dev).
 
 Follow the instructions for the top-level repo.
 
 1. `git clone` this repo & `cd` into it as usual
-2. Run `yarn` to install top-level dependencies.
+2. Run `pnpm install` to install top-level dependencies.
 
 ## Run
 
-- `yarn dev`
+- `pnpm dev`
 
 ## Test
 
-- `yarn lint` run just eslint
-- `yarn test` run lint and tests
+- `pnpm lint` runs oxlint
+- `pnpm test` runs lint and tests
 
 # Copyright & License
 

--- a/packages/email-mock-receiver/README.md
+++ b/packages/email-mock-receiver/README.md
@@ -8,7 +8,7 @@ Mocks email sending method and manages snapshots for outgoing email information 
 
 or
 
-`yarn add @tryghost/email-mock-receiver`
+`pnpm add @tryghost/email-mock-receiver`
 
 ## Purpose
 
@@ -23,9 +23,9 @@ This is a monorepo package.
 Follow the instructions for the top-level repo.
 
 1. `git clone` this repo & `cd` into it as usual
-2. Run `yarn` to install top-level dependencies.
+2. Run `pnpm install` to install top-level dependencies.
 
 ## Test
 
-- `yarn lint` run just eslint
-- `yarn test` run lint and tests
+- `pnpm lint` runs oxlint
+- `pnpm test` runs lint and tests

--- a/packages/errors/README.md
+++ b/packages/errors/README.md
@@ -6,7 +6,7 @@
 
 or
 
-`yarn add @tryghost/errors`
+`pnpm add @tryghost/errors`
 
 ## Purpose
 
@@ -16,21 +16,21 @@ Shared Ghost error classes and utilities for typed errors, context propagation, 
 
 ## Develop
 
-This is a mono repository, managed with [lerna](https://lernajs.io/).
+This is a mono repository, managed with [Nx](https://nx.dev).
 
 Follow the instructions for the top-level repo.
 
 1. `git clone` this repo & `cd` into it as usual
-2. Run `yarn` to install top-level dependencies.
+2. Run `pnpm install` to install top-level dependencies.
 
 ## Run
 
-- `yarn dev`
+- `pnpm dev`
 
 ## Test
 
-- `yarn lint` run just eslint
-- `yarn test` run lint and tests
+- `pnpm lint` runs oxlint
+- `pnpm test` runs lint and tests
 
 # Copyright & License
 

--- a/packages/express-test/README.md
+++ b/packages/express-test/README.md
@@ -8,7 +8,7 @@ Rapid express testing without HTTP
 
 or
 
-`yarn add @tryghost/express-test`
+`pnpm add @tryghost/express-test`
 
 ## Purpose
 
@@ -68,21 +68,21 @@ The custom order is here to prioritize assertions with the most context first. T
 
 ## Develop
 
-This is a mono repository, managed with [lerna](https://lernajs.io/).
+This is a mono repository, managed with [Nx](https://nx.dev).
 
 Follow the instructions for the top-level repo.
 
 1. `git clone` this repo & `cd` into it as usual
-2. Run `yarn` to install top-level dependencies.
+2. Run `pnpm install` to install top-level dependencies.
 
 ## Run
 
-- `yarn dev`
+- `pnpm dev`
 
 ## Test
 
-- `yarn lint` run just eslint
-- `yarn test` run lint and tests
+- `pnpm lint` runs oxlint
+- `pnpm test` runs lint and tests
 
 # Copyright & License
 

--- a/packages/http-cache-utils/README.md
+++ b/packages/http-cache-utils/README.md
@@ -8,7 +8,7 @@ Set of HTTP caching related utilities and constants
 
 or
 
-`yarn add @tryghost/http-cache-utils`
+`pnpm add @tryghost/http-cache-utils`
 
 ## Purpose
 
@@ -23,12 +23,12 @@ This is a monorepo package.
 Follow the instructions for the top-level repo.
 
 1. `git clone` this repo & `cd` into it as usual
-2. Run `yarn` to install top-level dependencies.
+2. Run `pnpm install` to install top-level dependencies.
 
 ## Test
 
-- `yarn lint` run just eslint
-- `yarn test` run lint and tests
+- `pnpm lint` runs oxlint
+- `pnpm test` runs lint and tests
 
 # Copyright & License
 

--- a/packages/http-stream/README.md
+++ b/packages/http-stream/README.md
@@ -8,7 +8,7 @@ A http stream to use alongside bunyan for logging
 
 or
 
-`yarn add @tryghost/http-stream`
+`pnpm add @tryghost/http-stream`
 
 ## Purpose
 
@@ -18,21 +18,21 @@ HTTP response streaming helper used for piping remote/local resources through Gh
 
 ## Develop
 
-This is a mono repository, managed with [lerna](https://lernajs.io/).
+This is a mono repository, managed with [Nx](https://nx.dev).
 
 Follow the instructions for the top-level repo.
 
 1. `git clone` this repo & `cd` into it as usual
-2. Run `yarn` to install top-level dependencies.
+2. Run `pnpm install` to install top-level dependencies.
 
 ## Run
 
-- `yarn dev`
+- `pnpm dev`
 
 ## Test
 
-- `yarn lint` run just eslint
-- `yarn test` run lint and tests
+- `pnpm lint` runs oxlint
+- `pnpm test` runs lint and tests
 
 # Copyright & License
 

--- a/packages/jest-snapshot/README.md
+++ b/packages/jest-snapshot/README.md
@@ -8,7 +8,7 @@ Tools for using jest snapshot without jest
 
 or
 
-`yarn add @tryghost/jest-snapshot`
+`pnpm add @tryghost/jest-snapshot`
 
 ## Purpose
 
@@ -18,21 +18,21 @@ Snapshot assertion utilities and state management for Jest-style snapshots in no
 
 ## Develop
 
-This is a mono repository, managed with [lerna](https://lernajs.io/).
+This is a mono repository, managed with [Nx](https://nx.dev).
 
 Follow the instructions for the top-level repo.
 
 1. `git clone` this repo & `cd` into it as usual
-2. Run `yarn` to install top-level dependencies.
+2. Run `pnpm install` to install top-level dependencies.
 
 ## Run
 
-- `yarn dev`
+- `pnpm dev`
 
 ## Test
 
-- `yarn lint` run just eslint
-- `yarn test` run lint and tests
+- `pnpm lint` runs oxlint
+- `pnpm test` runs lint and tests
 
 # Copyright & License
 

--- a/packages/logging/README.md
+++ b/packages/logging/README.md
@@ -6,7 +6,7 @@
 
 or
 
-`yarn add @tryghost/logging`
+`pnpm add @tryghost/logging`
 
 ## Purpose
 
@@ -16,21 +16,21 @@ Ghost logging layer that configures logger instances, transports, and structured
 
 ## Develop
 
-This is a mono repository, managed with [lerna](https://lernajs.io/).
+This is a mono repository, managed with [Nx](https://nx.dev).
 
 Follow the instructions for the top-level repo.
 
 1. `git clone` this repo & `cd` into it as usual
-2. Run `yarn` to install top-level dependencies.
+2. Run `pnpm install` to install top-level dependencies.
 
 ## Run
 
-- `yarn dev`
+- `pnpm dev`
 
 ## Test
 
-- `yarn lint` run just eslint
-- `yarn test` run lint and tests
+- `pnpm lint` runs oxlint
+- `pnpm test` runs lint and tests
 
 # Copyright & License
 

--- a/packages/metrics/README.md
+++ b/packages/metrics/README.md
@@ -6,7 +6,7 @@
 
 or
 
-`yarn add @tryghost/metrics`
+`pnpm add @tryghost/metrics`
 
 ## Purpose
 
@@ -16,21 +16,21 @@ Ghost metrics facade for collecting and emitting operational metrics across serv
 
 ## Develop
 
-This is a mono repository, managed with [lerna](https://lernajs.io/).
+This is a mono repository, managed with [Nx](https://nx.dev).
 
 Follow the instructions for the top-level repo.
 
 1. `git clone` this repo & `cd` into it as usual
-2. Run `yarn` to install top-level dependencies.
+2. Run `pnpm install` to install top-level dependencies.
 
 ## Run
 
-- `yarn dev`
+- `pnpm dev`
 
 ## Test
 
-- `yarn lint` run just eslint
-- `yarn test` run lint and tests
+- `pnpm lint` runs oxlint
+- `pnpm test` runs lint and tests
 
 # Copyright & License
 

--- a/packages/mw-error-handler/README.md
+++ b/packages/mw-error-handler/README.md
@@ -8,7 +8,7 @@ Express middleware helpers for Ghost-style API error handling.
 
 or
 
-`yarn add @tryghost/mw-error-handler`
+`pnpm add @tryghost/mw-error-handler`
 
 ## Purpose
 

--- a/packages/nodemailer/README.md
+++ b/packages/nodemailer/README.md
@@ -35,21 +35,21 @@ Factory for creating Nodemailer transports across SMTP, SES, Mailgun, Sendmail, 
 
 ## Develop
 
-This is a mono repository, managed with [lerna](https://lernajs.io/).
+This is a mono repository, managed with [Nx](https://nx.dev).
 
 Follow the instructions for the top-level repo.
 
 1. `git clone` this repo & `cd` into it as usual
-2. Run `yarn` to install top-level dependencies.
+2. Run `pnpm install` to install top-level dependencies.
 
 ## Run
 
-- `yarn dev`
+- `pnpm dev`
 
 ## Test
 
-- `yarn lint` run just eslint
-- `yarn test` run lint and tests
+- `pnpm lint` runs oxlint
+- `pnpm test` runs lint and tests
 
 # Copyright & License
 

--- a/packages/pretty-cli/README.md
+++ b/packages/pretty-cli/README.md
@@ -6,7 +6,7 @@ A mini-module to style a [sywac](http://sywac.io/) instance in a standard way
 
 Either: `npm install @tryghost/pretty-cli --save`
 
-Or: `yarn add @tryghost/pretty-cli`
+Or: `pnpm add @tryghost/pretty-cli`
 
 ## Purpose
 
@@ -51,8 +51,8 @@ The style rules used are available at `prettyCLI.styles`.
 
 ## Test
 
-- `yarn lint` run just eslint
-- `yarn test` run lint && tests
+- `pnpm lint` runs oxlint
+- `pnpm test` runs lint and tests
 
 # Copyright & License
 

--- a/packages/pretty-stream/README.md
+++ b/packages/pretty-stream/README.md
@@ -6,7 +6,7 @@
 
 or
 
-`yarn add @tryghost/pretty-stream`
+`pnpm add @tryghost/pretty-stream`
 
 ## Purpose
 
@@ -18,21 +18,21 @@ Used by `@tryghost/logging` and `@tryghost/metrics`.
 
 ## Develop
 
-This is a mono repository, managed with [lerna](https://lernajs.io/).
+This is a mono repository, managed with [Nx](https://nx.dev).
 
 Follow the instructions for the top-level repo.
 
 1. `git clone` this repo & `cd` into it as usual
-2. Run `yarn` to install top-level dependencies.
+2. Run `pnpm install` to install top-level dependencies.
 
 ## Run
 
-- `yarn dev`
+- `pnpm dev`
 
 ## Test
 
-- `yarn lint` run just eslint
-- `yarn test` run lint and tests
+- `pnpm lint` runs oxlint
+- `pnpm test` runs lint and tests
 
 # Copyright & License
 

--- a/packages/prometheus-metrics/README.md
+++ b/packages/prometheus-metrics/README.md
@@ -15,9 +15,9 @@ This is a monorepo package.
 Follow the instructions for the top-level repo.
 
 1. `git clone` this repo & `cd` into it as usual
-2. Run `yarn` to install top-level dependencies.
+2. Run `pnpm install` to install top-level dependencies.
 
 ## Test
 
-- `yarn lint` run just eslint
-- `yarn test` run lint and tests
+- `pnpm lint` runs oxlint
+- `pnpm test` runs lint and tests

--- a/packages/promise/README.md
+++ b/packages/promise/README.md
@@ -6,7 +6,7 @@
 
 or
 
-`yarn add @tryghost/promise`
+`pnpm add @tryghost/promise`
 
 ## Purpose
 
@@ -16,21 +16,21 @@ Small async utility module with `pipeline`, `sequence`, and `pool` helpers for P
 
 ## Develop
 
-This is a mono repository, managed with [lerna](https://lernajs.io/).
+This is a mono repository, managed with [Nx](https://nx.dev).
 
 Follow the instructions for the top-level repo.
 
 1. `git clone` this repo & `cd` into it as usual
-2. Run `yarn` to install top-level dependencies.
+2. Run `pnpm install` to install top-level dependencies.
 
 ## Run
 
-- `yarn dev`
+- `pnpm dev`
 
 ## Test
 
-- `yarn lint` run just eslint
-- `yarn test` run lint and tests
+- `pnpm lint` runs oxlint
+- `pnpm test` runs lint and tests
 
 # Copyright & License
 

--- a/packages/request/README.md
+++ b/packages/request/README.md
@@ -6,7 +6,7 @@
 
 or
 
-`yarn add @tryghost/request`
+`pnpm add @tryghost/request`
 
 ## Purpose
 
@@ -16,21 +16,21 @@ HTTP request abstraction used by Ghost for outbound calls, error handling, and r
 
 ## Develop
 
-This is a mono repository, managed with [lerna](https://lernajs.io/).
+This is a mono repository, managed with [Nx](https://nx.dev).
 
 Follow the instructions for the top-level repo.
 
 1. `git clone` this repo & `cd` into it as usual
-2. Run `yarn` to install top-level dependencies.
+2. Run `pnpm install` to install top-level dependencies.
 
 ## Run
 
-- `yarn dev`
+- `pnpm dev`
 
 ## Test
 
-- `yarn lint` run just eslint
-- `yarn test` run lint and tests
+- `pnpm lint` runs oxlint
+- `pnpm test` runs lint and tests
 
 # Copyright & License
 

--- a/packages/root-utils/README.md
+++ b/packages/root-utils/README.md
@@ -6,7 +6,7 @@
 
 or
 
-`yarn add @tryghost/root-utils`
+`pnpm add @tryghost/root-utils`
 
 ## Purpose
 
@@ -16,21 +16,21 @@ Utilities for resolving and working with the effective process root across Ghost
 
 ## Develop
 
-This is a mono repository, managed with [lerna](https://lernajs.io/).
+This is a mono repository, managed with [Nx](https://nx.dev).
 
 Follow the instructions for the top-level repo.
 
 1. `git clone` this repo & `cd` into it as usual
-2. Run `yarn` to install top-level dependencies.
+2. Run `pnpm install` to install top-level dependencies.
 
 ## Run
 
-- `yarn dev`
+- `pnpm dev`
 
 ## Test
 
-- `yarn lint` run just eslint
-- `yarn test` run lint and tests
+- `pnpm lint` runs oxlint
+- `pnpm test` runs lint and tests
 
 # Copyright & License
 

--- a/packages/security/README.md
+++ b/packages/security/README.md
@@ -8,7 +8,7 @@ Security helper primitives used by Ghost services.
 
 or
 
-`yarn add @tryghost/security`
+`pnpm add @tryghost/security`
 
 ## Purpose
 

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -6,7 +6,7 @@
 
 or
 
-`yarn add @tryghost/server`
+`pnpm add @tryghost/server`
 
 ## Purpose
 
@@ -16,21 +16,21 @@ HTTP server lifecycle helpers for starting/stopping servers and handling listen 
 
 ## Develop
 
-This is a mono repository, managed with [lerna](https://lernajs.io/).
+This is a mono repository, managed with [Nx](https://nx.dev).
 
 Follow the instructions for the top-level repo.
 
 1. `git clone` this repo & `cd` into it as usual
-2. Run `yarn` to install top-level dependencies.
+2. Run `pnpm install` to install top-level dependencies.
 
 ## Run
 
-- `yarn dev`
+- `pnpm dev`
 
 ## Test
 
-- `yarn lint` run just eslint
-- `yarn test` run lint and tests
+- `pnpm lint` runs oxlint
+- `pnpm test` runs lint and tests
 
 # Copyright & License
 

--- a/packages/tpl/README.md
+++ b/packages/tpl/README.md
@@ -6,7 +6,7 @@
 
 or
 
-`yarn add @tryghost/tpl`
+`pnpm add @tryghost/tpl`
 
 ## Purpose
 
@@ -30,21 +30,21 @@ console.error(tpl(messages.myError, {something: 'The thing'}));
 
 ## Develop
 
-This is a mono repository, managed with [lerna](https://lernajs.io/).
+This is a mono repository, managed with [Nx](https://nx.dev).
 
 Follow the instructions for the top-level repo.
 
 1. `git clone` this repo & `cd` into it as usual
-2. Run `yarn` to install top-level dependencies.
+2. Run `pnpm install` to install top-level dependencies.
 
 ## Run
 
-- `yarn dev`
+- `pnpm dev`
 
 ## Test
 
-- `yarn lint` run just eslint
-- `yarn test` run lint and tests
+- `pnpm lint` runs oxlint
+- `pnpm test` runs lint and tests
 
 # Copyright & License
 

--- a/packages/validator/README.md
+++ b/packages/validator/README.md
@@ -6,7 +6,7 @@
 
 or
 
-`yarn add @tryghost/validator`
+`pnpm add @tryghost/validator`
 
 ## Purpose
 
@@ -16,21 +16,21 @@ Ghost validation utilities built on validator.js, including custom validators an
 
 ## Develop
 
-This is a mono repository, managed with [lerna](https://lernajs.io/).
+This is a mono repository, managed with [Nx](https://nx.dev).
 
 Follow the instructions for the top-level repo.
 
 1. `git clone` this repo & `cd` into it as usual
-2. Run `yarn` to install top-level dependencies.
+2. Run `pnpm install` to install top-level dependencies.
 
 ## Run
 
-- `yarn dev`
+- `pnpm dev`
 
 ## Test
 
-- `yarn lint` run just eslint
-- `yarn test` run lint and tests
+- `pnpm lint` runs oxlint
+- `pnpm test` runs lint and tests
 
 # Copyright & License
 

--- a/packages/version/README.md
+++ b/packages/version/README.md
@@ -6,7 +6,7 @@
 
 or
 
-`yarn add @tryghost/version`
+`pnpm add @tryghost/version`
 
 ## Purpose
 
@@ -16,21 +16,21 @@ Version helpers that expose normalized Ghost version variants (`safe`, `full`, `
 
 ## Develop
 
-This is a mono repository, managed with [lerna](https://lernajs.io/).
+This is a mono repository, managed with [Nx](https://nx.dev).
 
 Follow the instructions for the top-level repo.
 
 1. `git clone` this repo & `cd` into it as usual
-2. Run `yarn` to install top-level dependencies.
+2. Run `pnpm install` to install top-level dependencies.
 
 ## Run
 
-- `yarn dev`
+- `pnpm dev`
 
 ## Test
 
-- `yarn lint` run just eslint
-- `yarn test` run lint and tests
+- `pnpm lint` runs oxlint
+- `pnpm test` runs lint and tests
 
 # Copyright & License
 

--- a/packages/webhook-mock-receiver/README.md
+++ b/packages/webhook-mock-receiver/README.md
@@ -8,7 +8,7 @@ Up to date documentation about the usage of the module available in [End-to-end 
 
 or
 
-`yarn add @tryghost/webhook-mock-receiver`
+`pnpm add @tryghost/webhook-mock-receiver`
 
 ## Purpose
 
@@ -18,21 +18,21 @@ Test utility for mocking webhook endpoints and asserting captured payload/header
 
 ## Develop
 
-This is a mono repository, managed with [lerna](https://lernajs.io/).
+This is a mono repository, managed with [Nx](https://nx.dev).
 
 Follow the instructions for the top-level repo.
 
 1. `git clone` this repo & `cd` into it as usual
-2. Run `yarn` to install top-level dependencies.
+2. Run `pnpm install` to install top-level dependencies.
 
 ## Run
 
-- `yarn dev`
+- `pnpm dev`
 
 ## Test
 
-- `yarn lint` run just eslint
-- `yarn test` run lint and tests
+- `pnpm lint` runs oxlint
+- `pnpm test` runs lint and tests
 
 # Copyright & License
 

--- a/packages/zip/README.md
+++ b/packages/zip/README.md
@@ -6,7 +6,7 @@
 
 or
 
-`yarn add @tryghost/zip`
+`pnpm add @tryghost/zip`
 
 ## Purpose
 
@@ -28,21 +28,21 @@ let res = await zip.extract('path/to/archive.zip', 'path/to/files', [options])
 
 ## Develop
 
-This is a mono repository, managed with [lerna](https://lernajs.io/).
+This is a mono repository, managed with [Nx](https://nx.dev).
 
 Follow the instructions for the top-level repo.
 
 1. `git clone` this repo & `cd` into it as usual
-2. Run `yarn` to install top-level dependencies.
+2. Run `pnpm install` to install top-level dependencies.
 
 ## Run
 
-- `yarn dev`
+- `pnpm dev`
 
 ## Test
 
-- `yarn lint` run just eslint
-- `yarn test` run lint and tests
+- `pnpm lint` runs oxlint
+- `pnpm test` runs lint and tests
 
 # Copyright & License
 


### PR DESCRIPTION
## Summary

Final pnpm-era cleanup. Every package README still referenced the old toolchain — `yarn` commands, `eslint`, and `lerna`. Sweep all 39 affected READMEs in one mechanical pass. **No code changes.**

Substitutions:

| before                                    | after                                   |
|-------------------------------------------|-----------------------------------------|
| `` `yarn add @tryghost/<pkg>` ``          | `` `pnpm add @tryghost/<pkg>` ``        |
| `` Run `yarn` to install... ``            | `` Run `pnpm install` to install... ``  |
| `` `yarn dev` / `yarn lint` / `yarn test` `` | `` `pnpm dev` / `pnpm lint` / `pnpm test` `` |
| `` `yarn lint` run just eslint ``         | `` `pnpm lint` runs oxlint ``           |
| `managed with [lerna](https://lernajs.io/)` | `managed with [Nx](https://nx.dev)`   |

## Deliberately untouched

- `packages/zip/test/fixtures/test-theme/README.md` — that's a test fixture (Casper theme) that's part of the zip package's test data, not our docs. Also already covered by `.oxfmtrc.json`'s `test/fixtures` ignore pattern.
- `packages/mw-vhost/README.md:11` — a `<!-- eslint-disable no-unused-vars -->` directive inside a JS code block. It's an in-doc lint hint, not a workflow reference; leaving it as a harmless artifact.

## Test plan

- [x] `pnpm format:check` — no new format issues introduced (3 pre-existing test-file issues on main unchanged)
- [x] `pnpm lint` — 42/42 green
- [ ] CI `Test` green on Node 22 and 24