### PR TITLE
Fixed cache key serialization dropping nested object keys

### DIFF
--- a/packages/api-framework/lib/pipeline.js
+++ b/packages/api-framework/lib/pipeline.js
@@ -7,6 +7,21 @@ const Frame = require('./Frame');
 const serializers = require('./serializers');
 const validators = require('./validators');
 
+// Replacer for JSON.stringify that returns every plain object with its keys
+// sorted, so the serialized output is deterministic at every depth. Unlike an
+// array replacer — which acts as a recursive key whitelist and silently drops
+// any key not present in the top-level list — this preserves all nested keys.
+function sortKeysReplacer(_key, value) {
+    if (value && typeof value === 'object' && !Array.isArray(value)) {
+        const sorted = {};
+        for (const k of Object.keys(value).sort()) {
+            sorted[k] = value[k];
+        }
+        return sorted;
+    }
+    return value;
+}
+
 const STAGES = {
     validation: {
         /**
@@ -247,7 +262,7 @@ const pipeline = (apiController, apiUtils, apiType) => {
                 cacheKeyData = await apiImpl.generateCacheKeyData(frame);
             }
 
-            const cacheKey = JSON.stringify(cacheKeyData, Object.keys(cacheKeyData).sort());
+            const cacheKey = JSON.stringify(cacheKeyData, sortKeysReplacer);
 
             if (apiImpl.cache) {
                 const response = await apiImpl.cache.get(cacheKey, getResponse);

--- a/packages/api-framework/test/pipeline.test.js
+++ b/packages/api-framework/test/pipeline.test.js
@@ -599,5 +599,58 @@ describe('Pipeline', function () {
                 'nested-field differences must produce distinct cache keys',
             );
         });
+
+        it('produces identical cache keys when cacheKeyData objects are reordered at any depth', async function () {
+            const cache = {
+                get: sinon.stub().resolves(null),
+                set: sinon.stub().resolves(true),
+            };
+
+            const apiController = {
+                browse: {
+                    cache,
+                    generateCacheKeyData: sinon.stub(),
+                },
+            };
+
+            const apiUtils = {};
+            const result = shared.pipeline(apiController, apiUtils);
+
+            shared.pipeline.STAGES.validation.input.resolves();
+            shared.pipeline.STAGES.serialisation.input.resolves();
+            shared.pipeline.STAGES.permissions.resolves();
+            shared.pipeline.STAGES.query.resolves('response');
+            shared.pipeline.STAGES.serialisation.output.callsFake(
+                function (response, _apiUtils, apiConfig, apiImpl, frame) {
+                    frame.response = response;
+                },
+            );
+
+            // Same logical payload, keys inserted in different orders at every
+            // depth (top-level, options, auth, and an object nested inside an
+            // array). Insertion order must not affect the cache key.
+            apiController.browse.generateCacheKeyData.onFirstCall().resolves({
+                options: { filter: 'status:published', limit: 15 },
+                auth: { free: false, tiers: [{ slug: 'gold', order: 1 }] },
+                method: 'browse',
+            });
+            apiController.browse.generateCacheKeyData.onSecondCall().resolves({
+                method: 'browse',
+                auth: { tiers: [{ order: 1, slug: 'gold' }], free: false },
+                options: { limit: 15, filter: 'status:published' },
+            });
+
+            await result.browse();
+            await result.browse();
+
+            const firstKey = cache.get.firstCall.args[0];
+            const secondKey = cache.get.secondCall.args[0];
+
+            assert.equal(
+                firstKey,
+                secondKey,
+                'key insertion order must not affect the cache key',
+            );
+        });
     });
 });

--- a/packages/api-framework/test/pipeline.test.js
+++ b/packages/api-framework/test/pipeline.test.js
@@ -546,5 +546,58 @@ describe('Pipeline', function () {
             // cache not set
             assert.equal(apiController.browse.cache.set.calledOnce, false);
         });
+
+        it('produces distinct cache keys when cacheKeyData objects differ only in nested fields', async function () {
+            const cache = {
+                get: sinon.stub().resolves(null),
+                set: sinon.stub().resolves(true),
+            };
+
+            const apiController = {
+                browse: {
+                    cache,
+                    generateCacheKeyData: sinon.stub(),
+                },
+            };
+
+            const apiUtils = {};
+            const result = shared.pipeline(apiController, apiUtils);
+
+            shared.pipeline.STAGES.validation.input.resolves();
+            shared.pipeline.STAGES.serialisation.input.resolves();
+            shared.pipeline.STAGES.permissions.resolves();
+            shared.pipeline.STAGES.query.resolves('response');
+            shared.pipeline.STAGES.serialisation.output.callsFake(
+                function (response, _apiUtils, apiConfig, apiImpl, frame) {
+                    frame.response = response;
+                },
+            );
+
+            // Two requests that share every top-level key but differ deep inside
+            // a nested object must not collide. Top-level keys are identical on
+            // purpose — that is what the replacer-array form silently dropped.
+            apiController.browse.generateCacheKeyData.onFirstCall().resolves({
+                options: { filter: 'status:published', limit: 15 },
+                auth: { free: true, tiers: [] },
+                method: 'browse',
+            });
+            apiController.browse.generateCacheKeyData.onSecondCall().resolves({
+                options: { filter: 'status:published', limit: 15 },
+                auth: { free: false, tiers: ['gold'] },
+                method: 'browse',
+            });
+
+            await result.browse();
+            await result.browse();
+
+            const firstKey = cache.get.firstCall.args[0];
+            const secondKey = cache.get.secondCall.args[0];
+
+            assert.notEqual(
+                firstKey,
+                secondKey,
+                'nested-field differences must produce distinct cache keys',
+            );
+        });
     });
 });


### PR DESCRIPTION
refs ONC-1676

The api-framework pipeline built its per-request cache key with `JSON.stringify(cacheKeyData, Object.keys(cacheKeyData).sort())`. The array form of the second argument to `JSON.stringify` is a recursive key whitelist — it is applied at every depth, not just the top level — so any key inside a nested object that did not also appear as a top-level key of `cacheKeyData` was silently dropped from the serialized output. Two calls whose `cacheKeyData` happened to agree on the top-level keys but differed somewhere inside a nested object therefore produced identical cache keys and collided in the cache.

The fix replaces the replacer array with a small `sortKeysReplacer` function. For every plain object the replacer visits — at any depth — it returns a new object with the same values but the keys iterated in sorted order, which keeps the output deterministic without discarding any nested keys. Arrays and primitives pass through untouched. The behaviour at the top level is the same as before; the difference is that nested objects now survive serialization intact.

Added a regression test in `packages/api-framework/test/pipeline.test.js` that stubs `generateCacheKeyData` to return two payloads with identical top-level keys but different nested fields and asserts the resulting cache keys are not equal. The test fails against the old replacer-array implementation and passes with the replacer function.

## Test plan

- [x] `pnpm --filter @tryghost/api-framework test` — 110/110 pass, including the new regression test