### PR TITLE
Tighten CI workflows: concurrency, format gate, nx cache

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,6 +14,9 @@ on:
         type: boolean
         default: true
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+
 jobs:
   publish:
     name: Publish to npm
@@ -38,8 +41,6 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - uses: pnpm/action-setup@903f9c1a6ebcba6cf41d87230be49611ac97822e # v6
-        with:
-          version: 10.33.0
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
@@ -47,15 +48,19 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
           cache: pnpm
 
+      - uses: actions/cache@v4
+        with:
+          path: .nx/cache
+          key: nx-${{ runner.os }}-publish-${{ hashFiles('pnpm-lock.yaml') }}-${{ github.sha }}
+          restore-keys: |
+            nx-${{ runner.os }}-publish-${{ hashFiles('pnpm-lock.yaml') }}-
+            nx-${{ runner.os }}-publish-
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --prefer-offline
 
       - name: Build releasable packages
         run: pnpm nx run-many -t build
-
-      # npm 11+ is required for npm Trusted Publishing (OIDC).
-      - name: Install npm 11
-        run: npm install -g npm@11
 
       - name: Configure npm registry
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,11 @@ on:
   push:
     branches:
       - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -18,8 +23,6 @@ jobs:
         with:
           fetch-depth: 0
       - uses: pnpm/action-setup@903f9c1a6ebcba6cf41d87230be49611ac97822e # v6
-        with:
-          version: 10.33.0
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         env:
           FORCE_COLOR: 0
@@ -27,7 +30,16 @@ jobs:
           node-version: ${{ matrix.node }}
           cache: pnpm
 
+      - uses: actions/cache@v4
+        with:
+          path: .nx/cache
+          key: nx-${{ runner.os }}-node${{ matrix.node }}-${{ hashFiles('pnpm-lock.yaml') }}-${{ github.sha }}
+          restore-keys: |
+            nx-${{ runner.os }}-node${{ matrix.node }}-${{ hashFiles('pnpm-lock.yaml') }}-
+            nx-${{ runner.os }}-node${{ matrix.node }}-
+
       - run: pnpm install --prefer-offline --frozen-lockfile
+      - run: pnpm format:check
       - run: pnpm test:ci
 
       - uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6

--- a/packages/api-framework/test/pipeline.test.js
+++ b/packages/api-framework/test/pipeline.test.js
@@ -646,11 +646,7 @@ describe('Pipeline', function () {
             const firstKey = cache.get.firstCall.args[0];
             const secondKey = cache.get.secondCall.args[0];
 
-            assert.equal(
-                firstKey,
-                secondKey,
-                'key insertion order must not affect the cache key',
-            );
+            assert.equal(firstKey, secondKey, 'key insertion order must not affect the cache key');
         });
     });
 });

--- a/packages/bookshelf-pagination/test/pagination-integration.test.js
+++ b/packages/bookshelf-pagination/test/pagination-integration.test.js
@@ -8,13 +8,13 @@ const knex = require('knex');
 const bookshelf = require('bookshelf');
 const paginationPlugin = require('../lib/bookshelf-pagination');
 
-const {hasMultiTableSource} = paginationPlugin.paginationUtils;
+const { hasMultiTableSource } = paginationPlugin.paginationUtils;
 
 async function setupDatabase() {
     const db = knex({
         client: 'sqlite3',
         useNullAsDefault: true,
-        connection: ':memory:'
+        connection: ':memory:',
     });
 
     await db.schema.createTable('authors', (t) => {
@@ -37,25 +37,25 @@ async function setupDatabase() {
     });
 
     await db('authors').insert([
-        {id: 'a1', name: 'Alice'},
-        {id: 'a2', name: 'Bob'}
+        { id: 'a1', name: 'Alice' },
+        { id: 'a2', name: 'Bob' },
     ]);
     await db('posts').insert([
-        {id: 'p1', title: 'one', status: 'published', author_id: 'a1'},
-        {id: 'p2', title: 'two', status: 'published', author_id: 'a1'},
-        {id: 'p3', title: 'three', status: 'draft', author_id: 'a2'}
+        { id: 'p1', title: 'one', status: 'published', author_id: 'a1' },
+        { id: 'p2', title: 'two', status: 'published', author_id: 'a1' },
+        { id: 'p3', title: 'three', status: 'draft', author_id: 'a2' },
     ]);
     await db('tags').insert([
-        {id: 't1', name: 'tech'},
-        {id: 't2', name: 'news'}
+        { id: 't1', name: 'tech' },
+        { id: 't2', name: 'news' },
     ]);
     // p1 has two tags — the outer-join cases below will duplicate p1 into
     // two physical rows, which is what makes count(*) vs count(distinct)
     // observable at the result level.
     await db('posts_tags').insert([
-        {post_id: 'p1', tag_id: 't1'},
-        {post_id: 'p1', tag_id: 't2'},
-        {post_id: 'p2', tag_id: 't1'}
+        { post_id: 'p1', tag_id: 't1' },
+        { post_id: 'p1', tag_id: 't2' },
+        { post_id: 'p2', tag_id: 't1' },
     ]);
 
     // Capture every compiled SQL query so each test can assert which count
@@ -68,13 +68,13 @@ async function setupDatabase() {
     const bk = bookshelf(db);
     paginationPlugin(bk);
 
-    const Post = bk.model('Post', {tableName: 'posts', idAttribute: 'id'});
+    const Post = bk.model('Post', { tableName: 'posts', idAttribute: 'id' });
 
-    return {db, Post, queries};
+    return { db, Post, queries };
 }
 
 function countQuerySql(queries) {
-    return queries.find(sql => typeof sql === 'string' && /\bcount\(/i.test(sql));
+    return queries.find((sql) => typeof sql === 'string' && /\bcount\(/i.test(sql));
 }
 
 describe('hasMultiTableSource against real knex builders', function () {
@@ -86,7 +86,7 @@ describe('hasMultiTableSource against real knex builders', function () {
     let db;
 
     beforeEach(function () {
-        db = knex({client: 'sqlite3', useNullAsDefault: true});
+        db = knex({ client: 'sqlite3', useNullAsDefault: true });
     });
 
     afterEach(async function () {
@@ -108,18 +108,30 @@ describe('hasMultiTableSource against real knex builders', function () {
     });
 
     it('returns true for an outer innerJoin', function () {
-        assert.equal(hasMultiTableSource(db('posts').innerJoin('tags', 'tags.id', 'posts.id')), true);
+        assert.equal(
+            hasMultiTableSource(db('posts').innerJoin('tags', 'tags.id', 'posts.id')),
+            true,
+        );
     });
 
     it('returns true for leftJoin, rightJoin and joinRaw', function () {
-        assert.equal(hasMultiTableSource(db('posts').leftJoin('tags', 'tags.id', 'posts.id')), true);
-        assert.equal(hasMultiTableSource(db('posts').joinRaw('right join tags on tags.id = posts.id')), true);
+        assert.equal(
+            hasMultiTableSource(db('posts').leftJoin('tags', 'tags.id', 'posts.id')),
+            true,
+        );
+        assert.equal(
+            hasMultiTableSource(db('posts').joinRaw('right join tags on tags.id = posts.id')),
+            true,
+        );
     });
 
     it('returns true for a UNION query', function () {
-        const qb = db('posts').select('id').where('status', 'published').union(function () {
-            this.select('id').from('posts').where('status', 'draft');
-        });
+        const qb = db('posts')
+            .select('id')
+            .where('status', 'published')
+            .union(function () {
+                this.select('id').from('posts').where('status', 'draft');
+            });
         assert.equal(hasMultiTableSource(qb), true);
     });
 
@@ -165,7 +177,7 @@ describe('fetchPage end-to-end against real bookshelf + sqlite', function () {
     let queries;
 
     beforeEach(async function () {
-        ({db, Post, queries} = await setupDatabase());
+        ({ db, Post, queries } = await setupDatabase());
     });
 
     afterEach(async function () {
@@ -180,10 +192,12 @@ describe('fetchPage end-to-end against real bookshelf + sqlite', function () {
         // count(distinct posts.id) must report 2.
         const result = await Post.forge()
             .query(function (qb) {
-                qb.innerJoin('posts_tags', 'posts_tags.post_id', 'posts.id')
-                    .where('posts.status', 'published');
+                qb.innerJoin('posts_tags', 'posts_tags.post_id', 'posts.id').where(
+                    'posts.status',
+                    'published',
+                );
             })
-            .fetchPage({page: 1, limit: 10, useSmartCount: true});
+            .fetchPage({ page: 1, limit: 10, useSmartCount: true });
 
         const countSql = countQuerySql(queries);
         assert.ok(usesCountDistinct(countSql), `expected count(distinct), got: ${countSql}`);
@@ -201,7 +215,7 @@ describe('fetchPage end-to-end against real bookshelf + sqlite', function () {
                         .where('authors.name', 'Alice');
                 });
             })
-            .fetchPage({page: 1, limit: 10, useSmartCount: true});
+            .fetchPage({ page: 1, limit: 10, useSmartCount: true });
 
         const countSql = countQuerySql(queries);
         assert.ok(usesCountStar(countSql), `expected count(*), got: ${countSql}`);

--- a/packages/bookshelf-pagination/test/pagination.test.js
+++ b/packages/bookshelf-pagination/test/pagination.test.js
@@ -17,7 +17,7 @@ function createBookshelf({ countRows, fetchResult, selectError, fetchError } = {
 
     const countQuery = {
         _statements: [],
-        _single: {table: 'posts'},
+        _single: { table: 'posts' },
         clone() {
             modelState.countCloned = true;
             return countQuery;
@@ -196,7 +196,7 @@ describe('@tryghost/bookshelf-pagination', function () {
     });
 
     it('passes the transacting option through to the count query', async function () {
-        const {bookshelf, modelState} = createBookshelf({countRows: [{aggregate: 1}]});
+        const { bookshelf, modelState } = createBookshelf({ countRows: [{ aggregate: 1 }] });
         const model = new bookshelf.Model();
 
         await model.fetchPage({
@@ -210,7 +210,7 @@ describe('@tryghost/bookshelf-pagination', function () {
     });
 
     it('handleRelation does not duplicate entries and ignores same-table properties', function () {
-        const {bookshelf} = createBookshelf();
+        const { bookshelf } = createBookshelf();
         const model = new bookshelf.Model();
         model.eagerLoad = ['authors'];
 

--- a/packages/metrics/test/metrics.test.js
+++ b/packages/metrics/test/metrics.test.js
@@ -203,13 +203,13 @@ describe('Logging', function () {
     it('ships object values with pre-set timestamp without adding metadata when disabled', async function () {
         const ghostMetrics = new GhostMetrics({
             metrics: {
-                transports: ['elasticsearch']
+                transports: ['elasticsearch'],
             },
             elasticsearch: {
                 host: 'https://test-elasticsearch',
                 username: 'user',
-                password: 'pass'
-            }
+                password: 'pass',
+            },
         });
 
         // Force metadata check false branch for coverage.
@@ -217,7 +217,7 @@ describe('Logging', function () {
 
         const payload = {
             value: 101,
-            '@timestamp': 12345
+            '@timestamp': 12345,
         };
 
         await new Promise((resolve) => {

--- a/packages/request/test/request.test.js
+++ b/packages/request/test/request.test.js
@@ -254,8 +254,8 @@ describe('Request', function () {
             method: 'PUT',
             body: 'hello',
             retry: {
-                limit: 0
-            }
+                limit: 0,
+            },
         }).then(function (res) {
             assert.equal(requestMock.isDone(), true);
             assert.equal(res.statusCode, 200);
@@ -266,7 +266,7 @@ describe('Request', function () {
         const requestModule = rewire('../lib/request');
         const gotStub = sinon.stub().resolves({
             statusCode: 200,
-            body: 'ok'
+            body: 'ok',
         });
         const originalNodeEnv = process.env.NODE_ENV;
 
@@ -274,13 +274,18 @@ describe('Request', function () {
         requestModule.__get__('defaultOptions').dnsLookup = () => {};
         delete process.env.NODE_ENV;
 
-        return requestModule('http://some-website.com/unset-env-endpoint/', {}).then((res) => {
-            assert.equal(res.statusCode, 200);
-            assert.equal(gotStub.calledOnce, true);
-            assert.equal(Object.prototype.hasOwnProperty.call(gotStub.firstCall.args[1], 'retry'), false);
-        }).finally(() => {
-            restoreNodeEnv(originalNodeEnv);
-        });
+        return requestModule('http://some-website.com/unset-env-endpoint/', {})
+            .then((res) => {
+                assert.equal(res.statusCode, 200);
+                assert.equal(gotStub.calledOnce, true);
+                assert.equal(
+                    Object.prototype.hasOwnProperty.call(gotStub.firstCall.args[1], 'retry'),
+                    false,
+                );
+            })
+            .finally(() => {
+                restoreNodeEnv(originalNodeEnv);
+            });
     });
 
     it('[success] can request successfully when NODE_ENV is unset', function () {
@@ -292,12 +297,14 @@ describe('Request', function () {
 
         delete process.env.NODE_ENV;
 
-        return request(url, {}).then((res) => {
-            assert.equal(requestMock.isDone(), true);
-            assert.equal(res.statusCode, 200);
-        }).finally(() => {
-            restoreNodeEnv(originalNodeEnv);
-        });
+        return request(url, {})
+            .then((res) => {
+                assert.equal(requestMock.isDone(), true);
+                assert.equal(res.statusCode, 200);
+            })
+            .finally(() => {
+                restoreNodeEnv(originalNodeEnv);
+            });
     });
 
     it('[failure] adds request options and response fields onto thrown error', function () {
@@ -333,19 +340,22 @@ describe('Request', function () {
         requestModule.__set__('got', gotStub);
         requestModule.__get__('defaultOptions').dnsLookup = () => {};
 
-        return requestModule('http://some-website.com/plain-error/', {retry: {limit: 0}}).then(() => {
-            throw new Error('Should have failed');
-        }, (err) => {
-            assert.equal(gotStub.calledOnce, true);
-            assert.equal(err, plainError);
-        });
+        return requestModule('http://some-website.com/plain-error/', { retry: { limit: 0 } }).then(
+            () => {
+                throw new Error('Should have failed');
+            },
+            (err) => {
+                assert.equal(gotStub.calledOnce, true);
+                assert.equal(err, plainError);
+            },
+        );
     });
 
     it('[success] does not force retry outside test environment', function () {
         const requestModule = rewire('../lib/request');
         const gotStub = sinon.stub().resolves({
             statusCode: 200,
-            body: 'ok'
+            body: 'ok',
         });
         const originalNodeEnv = process.env.NODE_ENV;
 
@@ -354,20 +364,25 @@ describe('Request', function () {
 
         process.env.NODE_ENV = 'production';
 
-        return requestModule('http://some-website.com/no-test-retry/').then((res) => {
-            assert.equal(res.statusCode, 200);
-            assert.equal(gotStub.calledOnce, true);
-            assert.equal(Object.prototype.hasOwnProperty.call(gotStub.firstCall.args[1], 'retry'), false);
-        }).finally(() => {
-            restoreNodeEnv(originalNodeEnv);
-        });
+        return requestModule('http://some-website.com/no-test-retry/')
+            .then((res) => {
+                assert.equal(res.statusCode, 200);
+                assert.equal(gotStub.calledOnce, true);
+                assert.equal(
+                    Object.prototype.hasOwnProperty.call(gotStub.firstCall.args[1], 'retry'),
+                    false,
+                );
+            })
+            .finally(() => {
+                restoreNodeEnv(originalNodeEnv);
+            });
     });
 
     it('[success] keeps explicit method when body is provided', function () {
         const requestModule = rewire('../lib/request');
         const gotStub = sinon.stub().resolves({
             statusCode: 200,
-            body: 'ok'
+            body: 'ok',
         });
 
         requestModule.__set__('got', gotStub);
@@ -377,8 +392,8 @@ describe('Request', function () {
             method: 'PUT',
             body: 'hello',
             retry: {
-                limit: 0
-            }
+                limit: 0,
+            },
         }).then(() => {
             assert.equal(gotStub.calledOnce, true);
             assert.equal(gotStub.firstCall.args[1].method, 'PUT');
@@ -391,7 +406,7 @@ describe('Request', function () {
 
         transportError.options = {
             method: 'GET',
-            url: 'http://some-website.com/transport-failure/'
+            url: 'http://some-website.com/transport-failure/',
         };
 
         const gotStub = sinon.stub().rejects(transportError);
@@ -401,16 +416,19 @@ describe('Request', function () {
 
         return requestModule('http://some-website.com/transport-failure/', {
             retry: {
-                limit: 0
-            }
-        }).then(() => {
-            throw new Error('Should have failed');
-        }, (err) => {
-            assert.equal(gotStub.calledOnce, true);
-            assert.equal(err.method, 'GET');
-            assert.equal(err.url, 'http://some-website.com/transport-failure/');
-            assert.equal(err.options, undefined);
-            assert.equal(err.response, undefined);
-        });
+                limit: 0,
+            },
+        }).then(
+            () => {
+                throw new Error('Should have failed');
+            },
+            (err) => {
+                assert.equal(gotStub.calledOnce, true);
+                assert.equal(err.method, 'GET');
+                assert.equal(err.url, 'http://some-website.com/transport-failure/');
+                assert.equal(err.options, undefined);
+                assert.equal(err.response, undefined);
+            },
+        );
     });
 });


### PR DESCRIPTION
## Summary

Four cheap wins on the CI workflows and a handful of format fixes that go with them.

### Concurrency groups
- **test.yml**: cancels stale PR runs (`cancel-in-progress` gated on `pull_request` so pushes to `main` never cancel each other)
- **publish.yml**: serializes without cancelling — we never want to cancel an in-flight publish, but we also don't want two running at once

### format:check gate
Added `pnpm format:check` to the test matrix. Five test files had pre-existing oxfmt drift; reformatting them is the other half of this PR so the gate is green on merge. Diffs are whitespace-only.

### .nx/cache caching
Added `actions/cache` for `.nx/cache` in both workflows. Keyed on lockfile + SHA, with progressive fallbacks. Gives cache hits on re-runs and branch incremental pushes. Bigger Nx savings (affected, etc.) land in PR 3.

### Redundant steps removed
- `npm install -g npm@11` in publish.yml — Node 24 ships with npm 11
- `version: 10.33.0` on both `pnpm/action-setup` steps — the root `packageManager` field drives the version, no need to duplicate

## Test plan

- [x] `pnpm format:check` passes locally
- [ ] CI green on this PR
- [ ] Nx cache hits visible in run logs (check second run on same SHA after a re-run)
- [ ] PR concurrency cancels a stale run (push a second commit and watch)