### PR TITLE
Faster root lint (30x) and more correct Nx caching

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -1,19 +1,40 @@
 {
   "$schema": "./node_modules/nx/schemas/nx-schema.json",
+  "namedInputs": {
+    "default": ["{projectRoot}/**/*", "sharedGlobals"],
+    "production": [
+      "default",
+      "!{projectRoot}/test/**/*",
+      "!{projectRoot}/**/*.test.{js,ts}",
+      "!{projectRoot}/**/*.md",
+      "!{projectRoot}/coverage/**/*",
+      "!{projectRoot}/vitest.config.ts"
+    ],
+    "sharedGlobals": [
+      "{workspaceRoot}/pnpm-lock.yaml",
+      "{workspaceRoot}/.oxlintrc.json",
+      "{workspaceRoot}/.oxfmtrc.json",
+      "{workspaceRoot}/vitest.config.ts",
+      "{workspaceRoot}/packages/tsconfig.json"
+    ]
+  },
   "targetDefaults": {
     "build": {
       "dependsOn": [
         "^build"
       ],
+      "inputs": ["production", "^production"],
       "cache": true
     },
     "lint": {
+      "inputs": ["default"],
       "cache": true
     },
     "test": {
       "dependsOn": [
         "^build"
       ],
+      "inputs": ["default", "^production"],
       "cache": true
     }
   },

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "setup": "pnpm install",
     "test": "nx run-many -t test --parallel=10 --outputStyle=dynamic-legacy",
     "test:ci": "nx run-many -t test --outputStyle=static",
-    "lint": "nx run-many -t lint --outputStyle=dynamic",
+    "lint": "oxlint -c .oxlintrc.json packages",
     "format": "oxfmt -c .oxfmtrc.json \"packages/**/*.{js,ts,json,md}\"",
     "format:check": "oxfmt -c .oxfmtrc.json --check \"packages/**/*.{js,ts,json,md}\"",
     "preship": "git diff --quiet && git diff --cached --quiet || (echo 'Error: working tree must be clean before shipping' && exit 1) && pnpm test",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,6 +7,7 @@ onlyBuiltDependencies:
   - esbuild
   - nx
   - sqlite3
+minimumReleaseAge: 1440
 catalog:
   sinon: 21.1.2
   typescript: 5.9.3


### PR DESCRIPTION
## Summary

Three hygiene/speed changes. No behavior changes to CI or which packages get built/tested.

### 1. Root lint: single-pass oxlint (30x faster)

Root \`pnpm lint\` was \`nx run-many -t lint\`, which spawns 42 node processes — one per package — just to run oxlint against 9ish files each. The overhead was process startup × 42, not the actual lint work.

Measured locally on this repo:
- **Cold \`nx run-many\`**: 14.6s
- **Warm \`nx run-many\` (all cache hits)**: 12.6s (still spawns 42 procs to check cache)
- **Single-pass \`oxlint -c .oxlintrc.json packages\`**: 0.4s (21ms actual lint)

Per-package \`lint\` scripts are unchanged — still useful when running \`posttest\` for a single package, and still wired into Nx if anyone wants \`nx affected -t lint\` later.

### 2. \`nx.json\` namedInputs

Makes the Nx cache aware of root-level config changes:
- Editing \`.oxlintrc.json\` / \`.oxfmtrc.json\` / root \`tsconfig.json\` / \`pnpm-lock.yaml\` now invalidates dependent caches (previously they wouldn't)
- \`build\` inputs exclude test files — so editing a test doesn't bust the build cache
- \`test\` inputs include everything in the project but only production inputs from deps

Today only 2 packages have \`build\` targets, so the immediate cache impact is small, but the shared-globals invalidation closes a real correctness gap.

### 3. \`minimumReleaseAge: 1440\` in pnpm-workspace.yaml

pnpm 10 feature: refuses to install package versions younger than 24 hours. Supply-chain guard — worth doing in a repo with active renovate auto-bumps, since attackers commonly rely on the window between publish and first CI detection.

## Test plan

- [x] \`pnpm lint\` runs clean in ~0.4s
- [x] \`pnpm exec nx run-many -t lint\` still works (per-package scripts intact)
- [x] \`pnpm install --frozen-lockfile\` clean
- [x] \`nx show project errors\` reports the new inputs correctly
- [ ] CI green