### PR TITLE
Run nx affected tests on PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,9 +38,19 @@ jobs:
             nx-${{ runner.os }}-node${{ matrix.node }}-${{ hashFiles('pnpm-lock.yaml') }}-
             nx-${{ runner.os }}-node${{ matrix.node }}-
 
+      - uses: nrwl/nx-set-shas@v4
+        if: github.event_name == 'pull_request'
+
       - run: pnpm install --prefer-offline --frozen-lockfile
       - run: pnpm format:check
-      - run: pnpm test:ci
+
+      - name: Test affected (PRs)
+        if: github.event_name == 'pull_request'
+        run: pnpm exec nx affected -t test --output-style=static
+
+      - name: Test all (main)
+        if: github.event_name == 'push'
+        run: pnpm test:ci
 
       - uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6
 

--- a/nx.json
+++ b/nx.json
@@ -12,17 +12,18 @@
     ],
     "sharedGlobals": [
       "{workspaceRoot}/pnpm-lock.yaml",
+      "{workspaceRoot}/pnpm-workspace.yaml",
+      "{workspaceRoot}/package.json",
       "{workspaceRoot}/.oxlintrc.json",
       "{workspaceRoot}/.oxfmtrc.json",
       "{workspaceRoot}/vitest.config.ts",
-      "{workspaceRoot}/packages/tsconfig.json"
+      "{workspaceRoot}/packages/tsconfig.json",
+      "{workspaceRoot}/.github/workflows/*.yml"
     ]
   },
   "targetDefaults": {
     "build": {
-      "dependsOn": [
-        "^build"
-      ],
+      "dependsOn": ["^build"],
       "inputs": ["production", "^production"],
       "cache": true
     },
@@ -31,17 +32,13 @@
       "cache": true
     },
     "test": {
-      "dependsOn": [
-        "^build"
-      ],
+      "dependsOn": ["^build"],
       "inputs": ["default", "^production"],
       "cache": true
     }
   },
   "release": {
-    "projects": [
-      "packages/*"
-    ],
+    "projects": ["packages/*"],
     "projectsRelationship": "independent",
     "version": {
       "preserveMatchingDependencyRanges": false,


### PR DESCRIPTION
## Summary

PRs only need to test packages touched by the change plus their dependents, not the entire workspace. This wires up \`nx-set-shas\` and \`nx affected -t test\` for PR events.

Main pushes are unchanged — they still run \`pnpm test:ci\` (full \`nx run-many -t test\`) so the global safety net is intact.

## How it works

- \`nrwl/nx-set-shas@v4\` runs only on PRs. It sets \`NX_BASE\` to the SHA of the last successful \`main\` run of this workflow and \`NX_HEAD\` to the PR head.
- \`nx affected -t test\` then walks the dependency graph from changed files and runs the \`test\` target only for affected projects.
- Root-config edits (\`nx.json\`, \`pnpm-lock.yaml\`, \`.oxlintrc.json\`, \`.oxfmtrc.json\`, root \`tsconfig.json\`, root \`vitest.config.ts\`) are declared as \`sharedGlobals\` in \`nx.json\` (via #568), so touching any of them correctly marks all projects affected.

## What gets skipped on a typical PR

Verified locally by editing \`packages/errors/src/index.ts\`:

\`\`\`
$ pnpm exec nx show projects --affected
[errors, bookshelf-pagination, bookshelf-plugins, bookshelf-collision,
 bookshelf-filter, mw-error-handler, api-framework, jest-snapshot,
 express-test, http-stream, logging, prometheus-metrics, domain-events,
 job-manager, server, nodemailer, validator, request, zip]
\`\`\`

19 projects affected (errors + 18 downstream dependents), 23 skipped.

A PR touching a leaf package like \`tpl\` affects just itself. A PR touching a widely-depended-on package like \`errors\` affects roughly half the repo.

## Non-changes (intentional)

- \`format:check\` still runs unconditionally. It takes ~150ms for the whole repo, so affected granularity isn't worth it.
- \`pnpm lint\` is not run in CI directly (it's already invoked per-package via the \`posttest\` hook), and since root lint is 0.4s (#568), there's no affected-lint story worth building.
- Concurrency, caching, format gate, and matrix are untouched from #563.

## Test plan

- [x] \`nx show projects --affected\` correctly identifies dependents when a source file is edited
- [x] Husky pre-commit fires clean on this PR
- [ ] First PR run: verify \`nx-set-shas\` succeeds and affected list is reasonable
- [ ] First main push after merge: verify full \`nx run-many\` still runs
- [ ] Inspect timing in Actions UI to confirm savings on subsequent PR runs