### PR TITLE
Standardize per-package test scripts

### DIFF
--- a/packages/api-framework/package.json
+++ b/packages/api-framework/package.json
@@ -17,8 +17,7 @@
   },
   "scripts": {
     "dev": "echo \"Implement me!\"",
-    "test:unit": "NODE_ENV=testing vitest run --coverage --config ../../vitest.config.ts",
-    "test": "pnpm run test:unit",
+    "test": "NODE_ENV=testing vitest run --coverage",
     "lint": "oxlint -c ../../.oxlintrc.json ."
   },
   "dependencies": {

--- a/packages/bookshelf-collision/package.json
+++ b/packages/bookshelf-collision/package.json
@@ -18,7 +18,7 @@
   },
   "scripts": {
     "dev": "echo \"Implement me!\"",
-    "test": "NODE_ENV=testing vitest run --coverage --config ../../vitest.config.ts",
+    "test": "NODE_ENV=testing vitest run --coverage",
     "lint": "oxlint -c ../../.oxlintrc.json .",
     "posttest": "pnpm run lint"
   },

--- a/packages/bookshelf-custom-query/package.json
+++ b/packages/bookshelf-custom-query/package.json
@@ -18,7 +18,7 @@
   },
   "scripts": {
     "dev": "echo \"Implement me!\"",
-    "test": "NODE_ENV=testing vitest run --coverage --config ../../vitest.config.ts",
+    "test": "NODE_ENV=testing vitest run --coverage",
     "lint": "oxlint -c ../../.oxlintrc.json .",
     "posttest": "pnpm run lint"
   },

--- a/packages/bookshelf-eager-load/package.json
+++ b/packages/bookshelf-eager-load/package.json
@@ -18,7 +18,7 @@
   },
   "scripts": {
     "dev": "echo \"Implement me!\"",
-    "test": "NODE_ENV=testing vitest run --coverage --config ../../vitest.config.ts",
+    "test": "NODE_ENV=testing vitest run --coverage",
     "lint": "oxlint -c ../../.oxlintrc.json .",
     "posttest": "pnpm run lint"
   },

--- a/packages/bookshelf-filter/package.json
+++ b/packages/bookshelf-filter/package.json
@@ -18,7 +18,7 @@
   },
   "scripts": {
     "dev": "echo \"Implement me!\"",
-    "test": "NODE_ENV=testing vitest run --coverage --config ../../vitest.config.ts",
+    "test": "NODE_ENV=testing vitest run --coverage",
     "lint": "oxlint -c ../../.oxlintrc.json .",
     "posttest": "pnpm run lint"
   },

--- a/packages/bookshelf-has-posts/package.json
+++ b/packages/bookshelf-has-posts/package.json
@@ -18,7 +18,7 @@
   },
   "scripts": {
     "dev": "echo \"Implement me!\"",
-    "test": "NODE_ENV=testing vitest run --coverage --config ../../vitest.config.ts",
+    "test": "NODE_ENV=testing vitest run --coverage",
     "lint": "oxlint -c ../../.oxlintrc.json .",
     "posttest": "pnpm run lint"
   },

--- a/packages/bookshelf-include-count/package.json
+++ b/packages/bookshelf-include-count/package.json
@@ -18,7 +18,7 @@
   },
   "scripts": {
     "dev": "echo \"Implement me!\"",
-    "test": "NODE_ENV=testing vitest run --coverage --config ../../vitest.config.ts",
+    "test": "NODE_ENV=testing vitest run --coverage",
     "lint": "oxlint -c ../../.oxlintrc.json .",
     "posttest": "pnpm run lint"
   },

--- a/packages/bookshelf-order/package.json
+++ b/packages/bookshelf-order/package.json
@@ -18,7 +18,7 @@
   },
   "scripts": {
     "dev": "echo \"Implement me!\"",
-    "test": "NODE_ENV=testing vitest run --coverage --config ../../vitest.config.ts",
+    "test": "NODE_ENV=testing vitest run --coverage",
     "lint": "oxlint -c ../../.oxlintrc.json .",
     "posttest": "pnpm run lint"
   },

--- a/packages/bookshelf-pagination/package.json
+++ b/packages/bookshelf-pagination/package.json
@@ -18,7 +18,7 @@
   },
   "scripts": {
     "dev": "echo \"Implement me!\"",
-    "test": "NODE_ENV=testing vitest run --coverage --config ../../vitest.config.ts",
+    "test": "NODE_ENV=testing vitest run --coverage",
     "lint": "oxlint -c ../../.oxlintrc.json .",
     "posttest": "pnpm run lint"
   },

--- a/packages/bookshelf-plugins/package.json
+++ b/packages/bookshelf-plugins/package.json
@@ -18,7 +18,7 @@
   },
   "scripts": {
     "dev": "echo \"Implement me!\"",
-    "test": "NODE_ENV=testing vitest run --coverage --config ../../vitest.config.ts",
+    "test": "NODE_ENV=testing vitest run --coverage",
     "lint": "oxlint -c ../../.oxlintrc.json .",
     "posttest": "pnpm run lint"
   },

--- a/packages/bookshelf-search/package.json
+++ b/packages/bookshelf-search/package.json
@@ -18,7 +18,7 @@
   },
   "scripts": {
     "dev": "echo \"Implement me!\"",
-    "test": "NODE_ENV=testing vitest run --coverage --config ../../vitest.config.ts",
+    "test": "NODE_ENV=testing vitest run --coverage",
     "lint": "oxlint -c ../../.oxlintrc.json .",
     "posttest": "pnpm run lint"
   },

--- a/packages/bookshelf-transaction-events/package.json
+++ b/packages/bookshelf-transaction-events/package.json
@@ -18,7 +18,7 @@
   },
   "scripts": {
     "dev": "echo \"Implement me!\"",
-    "test": "NODE_ENV=testing vitest run --coverage --config ../../vitest.config.ts",
+    "test": "NODE_ENV=testing vitest run --coverage",
     "lint": "oxlint -c ../../.oxlintrc.json .",
     "posttest": "pnpm run lint"
   },

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -18,7 +18,7 @@
   },
   "scripts": {
     "dev": "echo \"Implement me!\"",
-    "test": "NODE_ENV=testing vitest run --coverage --config ../../vitest.config.ts",
+    "test": "NODE_ENV=testing vitest run --coverage",
     "lint": "oxlint -c ../../.oxlintrc.json .",
     "posttest": "pnpm run lint"
   },

--- a/packages/database-info/package.json
+++ b/packages/database-info/package.json
@@ -18,7 +18,7 @@
   },
   "scripts": {
     "dev": "echo \"Implement me!\"",
-    "test": "NODE_ENV=testing vitest run --coverage --config ../../vitest.config.ts",
+    "test": "NODE_ENV=testing vitest run --coverage",
     "lint": "oxlint -c ../../.oxlintrc.json .",
     "posttest": "pnpm run lint"
   },

--- a/packages/debug/package.json
+++ b/packages/debug/package.json
@@ -18,7 +18,7 @@
   },
   "scripts": {
     "dev": "echo \"Implement me!\"",
-    "test": "NODE_ENV=testing vitest run --coverage --config ../../vitest.config.ts",
+    "test": "NODE_ENV=testing vitest run --coverage",
     "lint": "oxlint -c ../../.oxlintrc.json .",
     "posttest": "pnpm run lint"
   },

--- a/packages/domain-events/package.json
+++ b/packages/domain-events/package.json
@@ -19,8 +19,7 @@
   },
   "scripts": {
     "dev": "echo \"Implement me!\"",
-    "test:unit": "NODE_ENV=testing vitest run --coverage --config ../../vitest.config.ts",
-    "test": "pnpm run test:unit",
+    "test": "NODE_ENV=testing vitest run --coverage",
     "lint": "oxlint -c ../../.oxlintrc.json ."
   },
   "devDependencies": {

--- a/packages/elasticsearch/package.json
+++ b/packages/elasticsearch/package.json
@@ -18,7 +18,7 @@
   },
   "scripts": {
     "dev": "echo \"Implement me!\"",
-    "test": "NODE_ENV=testing vitest run --coverage --config ../../vitest.config.ts",
+    "test": "NODE_ENV=testing vitest run --coverage",
     "lint": "oxlint -c ../../.oxlintrc.json .",
     "posttest": "pnpm run lint"
   },

--- a/packages/email-mock-receiver/package.json
+++ b/packages/email-mock-receiver/package.json
@@ -18,8 +18,7 @@
   },
   "scripts": {
     "dev": "echo \"Implement me!\"",
-    "test:unit": "NODE_ENV=testing vitest run --coverage --config ../../vitest.config.ts",
-    "test": "pnpm run test:unit",
+    "test": "NODE_ENV=testing vitest run --coverage",
     "lint": "oxlint -c ../../.oxlintrc.json ."
   },
   "devDependencies": {

--- a/packages/http-cache-utils/package.json
+++ b/packages/http-cache-utils/package.json
@@ -18,8 +18,7 @@
   },
   "scripts": {
     "dev": "echo \"Implement me!\"",
-    "test:unit": "NODE_ENV=testing vitest run --coverage --config ../../vitest.config.ts",
-    "test": "pnpm run test:unit",
+    "test": "NODE_ENV=testing vitest run --coverage",
     "lint": "oxlint -c ../../.oxlintrc.json ."
   },
   "devDependencies": {

--- a/packages/http-stream/package.json
+++ b/packages/http-stream/package.json
@@ -18,7 +18,7 @@
   },
   "scripts": {
     "dev": "echo \"Implement me!\"",
-    "test": "NODE_ENV=testing vitest run --coverage --config ../../vitest.config.ts",
+    "test": "NODE_ENV=testing vitest run --coverage",
     "lint": "oxlint -c ../../.oxlintrc.json .",
     "posttest": "pnpm run lint"
   },

--- a/packages/jest-snapshot/package.json
+++ b/packages/jest-snapshot/package.json
@@ -18,7 +18,7 @@
   },
   "scripts": {
     "dev": "echo \"Implement me!\"",
-    "test": "NODE_ENV=testing vitest run --coverage --config ../../vitest.config.ts",
+    "test": "NODE_ENV=testing vitest run --coverage",
     "lint": "oxlint -c ../../.oxlintrc.json .",
     "posttest": "pnpm run lint"
   },

--- a/packages/job-manager/package.json
+++ b/packages/job-manager/package.json
@@ -18,8 +18,7 @@
   },
   "scripts": {
     "dev": "echo \"Implement me!\"",
-    "test:unit": "NODE_ENV=testing vitest run --coverage",
-    "test": "pnpm run test:unit",
+    "test": "NODE_ENV=testing vitest run --coverage",
     "lint": "oxlint -c ../../.oxlintrc.json ."
   },
   "dependencies": {

--- a/packages/logging/package.json
+++ b/packages/logging/package.json
@@ -18,7 +18,7 @@
   },
   "scripts": {
     "dev": "echo \"Implement me!\"",
-    "test": "NODE_ENV=testing vitest run --coverage --config ../../vitest.config.ts",
+    "test": "NODE_ENV=testing vitest run --coverage",
     "lint": "oxlint -c ../../.oxlintrc.json .",
     "posttest": "pnpm run lint"
   },

--- a/packages/mw-error-handler/package.json
+++ b/packages/mw-error-handler/package.json
@@ -19,8 +19,7 @@
   },
   "scripts": {
     "dev": "echo \"Implement me!\"",
-    "test:unit": "NODE_ENV=testing vitest run --coverage --config ../../vitest.config.ts",
-    "test": "pnpm run test:unit",
+    "test": "NODE_ENV=testing vitest run --coverage",
     "lint": "oxlint -c ../../.oxlintrc.json ."
   },
   "dependencies": {

--- a/packages/mw-vhost/package.json
+++ b/packages/mw-vhost/package.json
@@ -18,8 +18,7 @@
   },
   "scripts": {
     "dev": "echo \"Implement me!\"",
-    "test:unit": "NODE_ENV=testing vitest run --coverage --config ../../vitest.config.ts",
-    "test": "pnpm run test:unit",
+    "test": "NODE_ENV=testing vitest run --coverage",
     "lint": "oxlint -c ../../.oxlintrc.json ."
   },
   "devDependencies": {

--- a/packages/nodemailer/package.json
+++ b/packages/nodemailer/package.json
@@ -18,7 +18,7 @@
   },
   "scripts": {
     "dev": "echo \"Implement me!\"",
-    "test": "NODE_ENV=testing vitest run --coverage --config ../../vitest.config.ts",
+    "test": "NODE_ENV=testing vitest run --coverage",
     "lint": "oxlint -c ../../.oxlintrc.json .",
     "posttest": "pnpm run lint"
   },

--- a/packages/pretty-cli/package.json
+++ b/packages/pretty-cli/package.json
@@ -19,7 +19,7 @@
   },
   "scripts": {
     "dev": "echo \"Implement me!\"",
-    "test": "NODE_ENV=testing vitest run --coverage --config ../../vitest.config.ts",
+    "test": "NODE_ENV=testing vitest run --coverage",
     "lint": "oxlint -c ../../.oxlintrc.json .",
     "posttest": "pnpm run lint"
   },

--- a/packages/pretty-stream/package.json
+++ b/packages/pretty-stream/package.json
@@ -18,7 +18,7 @@
   },
   "scripts": {
     "dev": "echo \"Implement me!\"",
-    "test": "NODE_ENV=testing vitest run --coverage --config ../../vitest.config.ts",
+    "test": "NODE_ENV=testing vitest run --coverage",
     "lint": "oxlint -c ../../.oxlintrc.json .",
     "posttest": "pnpm run lint"
   },

--- a/packages/promise/package.json
+++ b/packages/promise/package.json
@@ -18,7 +18,7 @@
   },
   "scripts": {
     "dev": "echo \"Implement me!\"",
-    "test": "NODE_ENV=testing vitest run --coverage --config ../../vitest.config.ts",
+    "test": "NODE_ENV=testing vitest run --coverage",
     "lint": "oxlint -c ../../.oxlintrc.json .",
     "posttest": "pnpm run lint"
   },

--- a/packages/request/package.json
+++ b/packages/request/package.json
@@ -18,7 +18,7 @@
   },
   "scripts": {
     "dev": "echo \"Implement me!\"",
-    "test": "NODE_ENV=testing vitest run --coverage --config ../../vitest.config.ts",
+    "test": "NODE_ENV=testing vitest run --coverage",
     "lint": "oxlint -c ../../.oxlintrc.json .",
     "posttest": "pnpm run lint"
   },

--- a/packages/security/package.json
+++ b/packages/security/package.json
@@ -19,8 +19,7 @@
   },
   "scripts": {
     "dev": "echo \"Implement me!\"",
-    "test:unit": "NODE_ENV=testing vitest run --coverage --config ../../vitest.config.ts",
-    "test": "pnpm run test:unit",
+    "test": "NODE_ENV=testing vitest run --coverage",
     "lint": "oxlint -c ../../.oxlintrc.json ."
   },
   "dependencies": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -18,7 +18,7 @@
   },
   "scripts": {
     "dev": "echo \"Implement me!\"",
-    "test": "NODE_ENV=testing vitest run --coverage --config ../../vitest.config.ts",
+    "test": "NODE_ENV=testing vitest run --coverage",
     "lint": "oxlint -c ../../.oxlintrc.json .",
     "posttest": "pnpm run lint"
   },

--- a/packages/tpl/package.json
+++ b/packages/tpl/package.json
@@ -18,7 +18,7 @@
   },
   "scripts": {
     "dev": "echo \"Implement me!\"",
-    "test": "NODE_ENV=testing vitest run --coverage --config ../../vitest.config.ts",
+    "test": "NODE_ENV=testing vitest run --coverage",
     "lint": "oxlint -c ../../.oxlintrc.json .",
     "posttest": "pnpm run lint"
   },

--- a/packages/validator/package.json
+++ b/packages/validator/package.json
@@ -18,7 +18,7 @@
   },
   "scripts": {
     "dev": "echo \"Implement me!\"",
-    "test": "NODE_ENV=testing vitest run --coverage --config ../../vitest.config.ts",
+    "test": "NODE_ENV=testing vitest run --coverage",
     "lint": "oxlint -c ../../.oxlintrc.json .",
     "posttest": "pnpm run lint"
   },

--- a/packages/webhook-mock-receiver/package.json
+++ b/packages/webhook-mock-receiver/package.json
@@ -18,7 +18,7 @@
   },
   "scripts": {
     "dev": "echo \"Implement me!\"",
-    "test": "NODE_ENV=testing vitest run --coverage --config ../../vitest.config.ts",
+    "test": "NODE_ENV=testing vitest run --coverage",
     "lint": "oxlint -c ../../.oxlintrc.json .",
     "posttest": "pnpm run lint"
   },

--- a/packages/zip/package.json
+++ b/packages/zip/package.json
@@ -18,7 +18,7 @@
   },
   "scripts": {
     "dev": "echo \"Implement me!\"",
-    "test": "NODE_ENV=testing vitest run --coverage --config ../../vitest.config.ts",
+    "test": "NODE_ENV=testing vitest run --coverage",
     "lint": "oxlint -c ../../.oxlintrc.json .",
     "posttest": "pnpm run lint"
   },

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
         globals: true,
         environment: 'node',
         include: ['test/**/*.test.{js,ts}'],
+        pool: 'threads',
         coverage: {
             provider: 'v8',
             include: ['**/lib/**'],

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,11 +1,10 @@
-import {defineConfig} from 'vitest/config';
+import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
     test: {
         globals: true,
         environment: 'node',
         include: ['test/**/*.test.{js,ts}'],
-        pool: 'threads',
         coverage: {
             provider: 'v8',
             include: ['**/lib/**'],
@@ -15,8 +14,8 @@ export default defineConfig({
                 lines: 90,
                 functions: 90,
                 branches: 80,
-                statements: 90
-            }
-        }
-    }
+                statements: 90,
+            },
+        },
+    },
 });


### PR DESCRIPTION
## Summary

Pure cleanup — every package's \`test\` script now has the same shape, and three kinds of drift are gone:

### Before (3 variants)

\`\`\`jsonc
// most packages
"test": "NODE_ENV=testing vitest run --coverage --config ../../vitest.config.ts"

// already auto-discovering (5 packages)
"test": "NODE_ENV=testing vitest run --coverage"

// vestigial indirection (8 packages)
"test": "pnpm run test:unit",
"test:unit": "NODE_ENV=testing vitest run --coverage --config ../../vitest.config.ts"
\`\`\`

### After (1 variant)

\`\`\`jsonc
"test": "NODE_ENV=testing vitest run --coverage"
\`\`\`

## Why this is safe

- **\`--config ../../vitest.config.ts\` is unnecessary.** Vitest auto-discovers a \`vitest.config.ts\` walking up from cwd. Verified identical behavior (same test files discovered, same coverage scope, same pass count) with and without the flag.
- **\`test:unit\` was never expanded into \`test:integration\`.** The wrapper added a second script for zero value in 8 packages. Collapsed.
- **prometheus-metrics keeps its compound pattern** (\`test: pnpm run test:types && pnpm run test:unit\`) because it has a legitimate \`tsc --noEmit\` step alongside unit tests.

## Also in this PR

Dropped \`pool: 'threads'\` from the root \`vitest.config.ts\` — it's the default in Vitest 4.x.

## Test plan

- [x] \`pnpm test:ci\` passes (42 projects)
- [x] \`pnpm format:check\` passes
- [x] Packages with local \`vitest.config.ts\` overrides still use their local file (vitest discovers local first, then walks up)
- [ ] CI green