### PR TITLE
Override axios to ^1.15.0 to close 5 CVEs

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,7 @@ catalogs:
 
 overrides:
   node-loggly-bulk: ^4.0.2
+  axios: ^1.15.0
 
 importers:
 
@@ -2758,9 +2759,6 @@ packages:
   axios@1.15.2:
     resolution: {integrity: sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==}
 
-  axios@1.7.4:
-    resolution: {integrity: sha512-DukmaFRnY6AzAALSH4J2M3k6PkaC+MfaAGdEERRWcC9q3/TWQwLpHR8ZRLKTdQ3aBDL64EdluRDjJqKw+BPZEw==}
-
   b4a@1.8.0:
     resolution: {integrity: sha512-qRuSmNSkGQaHwNbM7J78Wwy+ghLEYF1zNrSeMxj4Kgw6y33O3mXcQ6Ie9fRvfU/YnxWkOchPXbaLb73TkIsfdg==}
     peerDependencies:
@@ -4769,9 +4767,6 @@ packages:
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
-
-  proxy-from-env@1.1.0:
-    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
 
   proxy-from-env@2.1.0:
     resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
@@ -7916,14 +7911,6 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  axios@1.7.4:
-    dependencies:
-      follow-redirects: 1.16.0
-      form-data: 4.0.5
-      proxy-from-env: 1.1.0
-    transitivePeerDependencies:
-      - debug
-
   b4a@1.8.0: {}
 
   babel-plugin-const-enum@1.2.0(@babel/core@7.29.0):
@@ -9551,7 +9538,7 @@ snapshots:
 
   node-loggly-bulk@4.0.2:
     dependencies:
-      axios: 1.7.4
+      axios: 1.15.2
       json-stringify-safe: 5.0.1
       moment: 2.29.4
     transitivePeerDependencies:
@@ -9921,8 +9908,6 @@ snapshots:
     dependencies:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
-
-  proxy-from-env@1.1.0: {}
 
   proxy-from-env@2.1.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,6 +2,7 @@ packages:
   - 'packages/*'
 overrides:
   node-loggly-bulk: ^4.0.2
+  axios: ^1.15.0
 onlyBuiltDependencies:
   - dtrace-provider
   - esbuild


### PR DESCRIPTION
## Summary

Closes 5 open dependabot advisories against \`axios <1.15.0\` — all reached via the same transitive path:

\`\`\`
packages/logging → bunyan-loggly → node-loggly-bulk@4.0.2 → axios@1.7.4
\`\`\`

\`node-loggly-bulk\` pins axios to an exact version (\`"1.7.4"\`, not a range), so the only way to get a patched axios in is a workspace override.

## Advisories closed

| Severity | ID | Summary |
|---|---|---|
| High | [GHSA-43fc-jf86-j433](https://github.com/advisories/GHSA-43fc-jf86-j433) | DoS via \`__proto__\` key in \`mergeConfig\` |
| High | [GHSA-4hjh-wcwx-xvwj](https://github.com/advisories/GHSA-4hjh-wcwx-xvwj) | DoS via lack of data-size check |
| High | [GHSA-jr5f-v2jv-69x6](https://github.com/advisories/GHSA-jr5f-v2jv-69x6) | SSRF + credential leakage via absolute URL |
| Medium | [GHSA-3p68-rc4w-qgx5](https://github.com/advisories/GHSA-3p68-rc4w-qgx5) | NO_PROXY hostname normalization bypass → SSRF |
| Medium | [GHSA-fvcv-3m26-pcqx](https://github.com/advisories/GHSA-fvcv-3m26-pcqx) | Cloud metadata exfiltration via header injection |

## Why the override is safe

- axios 1.x has been API-stable on its HTTP surface since the 1.0 release. All breakage happened at the 0.x → 1.x boundary years ago.
- \`node-loggly-bulk\`'s usage is narrow: a plain POST with JSON body, handle response or error. None of the 1.8–1.15 changes touch that path.
- Verified locally: \`pnpm test:ci\` passes (42 projects, 1 dependent task). \`pnpm audit --prod\` drops from **9 vulnerabilities (5 moderate + 4 high)** to **4 (3 moderate + 1 high)**.

## What this does NOT fix

The remaining 4 advisories are in other packages (\`validator\`, \`fast-xml-parser\`, \`uuid\`) and need separate attention.

## Longer-term concern

\`bunyan-loggly\` and \`node-loggly-bulk\` are unmaintained upstream, and \`node-loggly-bulk\` pins axios exactly, so we will be re-opening this PR on every future axios CVE.