### PR TITLE
Override fast-xml-parser to ^5.7.0 to close CVE

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,6 +16,7 @@ catalogs:
 overrides:
   node-loggly-bulk: ^4.0.2
   axios: ^1.15.0
+  fast-xml-parser: ^5.7.0
 
 importers:
 
@@ -1831,6 +1832,9 @@ packages:
     resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
     engines: {node: ^14.21.3 || >=16}
 
+  '@nodable/entities@2.1.0':
+    resolution: {integrity: sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==}
+
   '@nx/devkit@22.6.5':
     resolution: {integrity: sha512-9kvAI+kk2pfEXLqS8OyjI9XvWmp+Gdn7jPfxDAz8BOqxMyPy3p5hYl+jc4TIsLOWunAFl8azqrcYsHzEpaWCIA==}
     peerDependencies:
@@ -3644,8 +3648,8 @@ packages:
   fast-xml-builder@1.1.5:
     resolution: {integrity: sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==}
 
-  fast-xml-parser@5.5.8:
-    resolution: {integrity: sha512-Z7Fh2nVQSb2d+poDViM063ix2ZGt9jmY1nWhPfHBOK2Hgnb/OW3P4Et3P/81SEej0J7QbWtJqxO05h8QYfK7LQ==}
+  fast-xml-parser@5.7.1:
+    resolution: {integrity: sha512-8Cc3f8GUGUULg34pBch/KGyPLglS+OFs05deyOlY7fL2MTagYPKrVQNmR1fLF/yJ9PH5ZSTd3YDF6pnmeZU+zA==}
     hasBin: true
 
   fastq@1.20.1:
@@ -5871,7 +5875,7 @@ snapshots:
   '@aws-sdk/xml-builder@3.972.18':
     dependencies:
       '@smithy/types': 4.14.1
-      fast-xml-parser: 5.5.8
+      fast-xml-parser: 5.7.1
       tslib: 2.8.1
 
   '@aws/lambda-invoke-store@0.2.4': {}
@@ -6975,6 +6979,8 @@ snapshots:
     optional: true
 
   '@noble/hashes@1.8.0': {}
+
+  '@nodable/entities@2.1.0': {}
 
   '@nx/devkit@22.6.5(nx@22.6.5)':
     dependencies:
@@ -8690,8 +8696,9 @@ snapshots:
     dependencies:
       path-expression-matcher: 1.5.0
 
-  fast-xml-parser@5.5.8:
+  fast-xml-parser@5.7.1:
     dependencies:
+      '@nodable/entities': 2.1.0
       fast-xml-builder: 1.1.5
       path-expression-matcher: 1.5.0
       strnum: 2.2.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,6 +3,7 @@ packages:
 overrides:
   node-loggly-bulk: ^4.0.2
   axios: ^1.15.0
+  fast-xml-parser: ^5.7.0
 onlyBuiltDependencies:
   - dtrace-provider
   - esbuild


### PR DESCRIPTION
## Summary

Closes [GHSA-gh4j-gqv2-49f6](https://github.com/advisories/GHSA-gh4j-gqv2-49f6) (moderate) — \`fast-xml-parser\` XMLBuilder is vulnerable to XML Comment and CDATA injection via unescaped delimiters. The fix shipped in 5.7.0.

## Why an override instead of a dep bump

The vulnerable package is deep transitive:

\`\`\`
packages/nodemailer → @aws-sdk/client-sesv2 → @aws-sdk/core → @aws-sdk/xml-builder → fast-xml-parser
\`\`\`

\`@aws-sdk/xml-builder\` pins \`fast-xml-parser\` to an exact version (\`"5.5.8"\`, not a range), and the latest published \`@aws-sdk/xml-builder@3.972.18\` still pins 5.5.8. So bumping the AWS SDK doesn't help — we'd still end up on 5.5.8. Workspace override is the only mitigation.

## Why it's safe

- \`fast-xml-parser\` 5.x is API-stable on the XMLBuilder surface AWS uses to build XML requests
- The 5.7.0 change is literally the CVE fix (delimiter escaping) — non-breaking semver-wise
- \`@tryghost/nodemailer\` tests pass with the new version
- Full test suite (42 projects) passes

## Forever-maintenance concern

Same pattern as the axios override: AWS SDK pins exactly, so each future fast-xml-parser CVE will require updating the override here. When AWS picks up a non-vulnerable baseline, we can drop the override.

## Test plan

- [x] \`pnpm install\` succeeds with \`fast-xml-parser@5.7.1\` resolved
- [x] \`pnpm --filter @tryghost/nodemailer test\` passes (100% coverage maintained)
- [x] \`pnpm test:ci\` passes (42 projects)
- [ ] CI green