### PR TITLE
Remove dead uuid devDependency from @tryghost/security

### DIFF
--- a/packages/security/package.json
+++ b/packages/security/package.json
@@ -27,7 +27,6 @@
     "bcryptjs": "3.0.3"
   },
   "devDependencies": {
-    "sinon": "catalog:",
-    "uuid": "13.0.0"
+    "sinon": "catalog:"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -676,9 +676,6 @@ importers:
       sinon:
         specifier: 'catalog:'
         version: 21.1.2
-      uuid:
-        specifier: 13.0.0
-        version: 13.0.0
 
   packages/server:
     dependencies:
@@ -5322,10 +5319,6 @@ packages:
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
-
-  uuid@13.0.0:
-    resolution: {integrity: sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==}
-    hasBin: true
 
   validator@7.2.0:
     resolution: {integrity: sha512-c8NGTUYeBEcUIGeMppmNVKHE7wwfm3mYbNZxV+c5mlv9fDHI7Ad3p07qfNrn/CvpdkK2k61fOLRO2sTEhgQXmg==}
@@ -10508,8 +10501,6 @@ snapshots:
   url-join@4.0.1: {}
 
   util-deprecate@1.0.2: {}
-
-  uuid@13.0.0: {}
 
   validator@7.2.0: {}
 


### PR DESCRIPTION
## Summary

Closes [GHSA-w5hq-g745-h8pq](https://github.com/advisories/GHSA-w5hq-g745-h8pq) (moderate) — \`uuid\` missing buffer bounds check in v3/v5/v6 when \`buf\` is provided.

**The fix is to delete the dep.** \`uuid@13.0.0\` was declared as a devDependency in \`packages/security/package.json\` but is not imported anywhere — not in \`lib/\`, not in \`test/\`, not in any other package in this repo. It's dead weight from some earlier cleanup that didn't complete.

## Verification the dep is actually dead

\`\`\`
$ grep -rn "uuid" packages/security/ --exclude-dir=node_modules
packages/security/package.json:31:    "uuid": "13.0.0"
\`\`\`

One match — the declaration itself. No \`require\`, no \`import\`, no reference in any source or test file.

Other repo-wide uuid mentions:
- \`packages/api-framework/lib/validators/input/all.js:21\` — \`uuid: { isUUID: true }\` — a string reference to \`@tryghost/validator\`'s \`isUUID\` function, not the \`uuid\` package
- \`@smithy/uuid\` — a different package (AWS's own internal uuid), not affected by this advisory

## Why delete instead of bump

Bumping to \`uuid@14.0.0\` would also close the advisory, but since the dep isn't used, every byte in \`pnpm-lock.yaml\` for uuid is pure overhead. Removing is cleaner and retires the package from the graph entirely.

## Test plan

- [x] \`pnpm install\` clean; uuid gone from lockfile
- [x] \`pnpm --filter @tryghost/security test\` passes (100% coverage maintained)
- [x] \`pnpm test:ci\` passes (42 projects)
- [x] \`pnpm audit\` drops from 4 vulnerabilities to 3
- [ ] CI green