### PR TITLE
Downgraded ElasticSearch to version 8

### DIFF
--- a/packages/elasticsearch/package.json
+++ b/packages/elasticsearch/package.json
@@ -23,7 +23,7 @@
     "posttest": "pnpm run lint"
   },
   "dependencies": {
-    "@elastic/elasticsearch": "9.3.4",
+    "@elastic/elasticsearch": "8.19.1",
     "@tryghost/debug": "workspace:*",
     "split2": "4.2.0"
   },

--- a/packages/elasticsearch/test/ElasticSearch.test.js
+++ b/packages/elasticsearch/test/ElasticSearch.test.js
@@ -1,10 +1,20 @@
 const assert = require('assert/strict');
+const fs = require('fs');
+const path = require('path');
 const sinon = require('sinon');
 const sandbox = sinon.createSandbox();
 
 const { Client } = require('@elastic/elasticsearch');
 const ElasticSearch = require('../index');
 const ElasticSearchBunyan = require('../lib/ElasticSearchBunyan');
+
+const EXPECTED_ELASTICSEARCH_MAJOR = 8;
+const elasticsearchPackage = JSON.parse(
+    fs.readFileSync(
+        path.join(path.dirname(require.resolve('@elastic/elasticsearch')), 'package.json'),
+        'utf8',
+    ),
+);
 
 const testClientConfig = {
     node: 'http://test-elastic-client',
@@ -22,6 +32,15 @@ const indexConfig = {
 describe('ElasticSearch', function () {
     afterEach(function () {
         sandbox.restore();
+    });
+
+    it(`Uses @elastic/elasticsearch v${EXPECTED_ELASTICSEARCH_MAJOR}`, function () {
+        const installedMajor = Number(elasticsearchPackage.version.split('.')[0]);
+        assert.equal(
+            installedMajor,
+            EXPECTED_ELASTICSEARCH_MAJOR,
+            `Expected @elastic/elasticsearch v${EXPECTED_ELASTICSEARCH_MAJOR}, got v${elasticsearchPackage.version}`,
+        );
     });
 
     it('Processes client configuration', function () {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -272,8 +272,8 @@ importers:
   packages/elasticsearch:
     dependencies:
       '@elastic/elasticsearch':
-        specifier: 9.3.4
-        version: 9.3.4
+        specifier: 8.19.1
+        version: 8.19.1
       '@tryghost/debug':
         specifier: workspace:*
         version: link:../debug
@@ -1504,13 +1504,13 @@ packages:
     resolution: {integrity: sha512-EVMD0SgJtOuFeg0lAVbCwa+qeTKILb87jqvLyUtQswGD9+ce2nB52Y5zbTF1Hc0MDFfbydcMcxb47jSdhikVHA==}
     engines: {node: '>= 10'}
 
-  '@elastic/elasticsearch@9.3.4':
-    resolution: {integrity: sha512-Mp14fPEYx+WTfZdcvAaZ9WkLYGHQCbwMx6EP5VCucYdhv4cn/g2sbnMT5HzK+gX3XEpBnnkEK/+WysCKzxuo3A==}
+  '@elastic/elasticsearch@8.19.1':
+    resolution: {integrity: sha512-+1j9NnQVOX+lbWB8LhCM7IkUmjU05Y4+BmSLfusq0msCsQb1Va+OUKFCoOXjCJqQrcgdRdQCjYYyolQ/npQALQ==}
     engines: {node: '>=18'}
 
-  '@elastic/transport@9.3.5':
-    resolution: {integrity: sha512-hIMJbt1guqr3/N2zCN45k9hw9o78qcdsO0xietLe+Bfa+JL0YafHTgkWkM1oT3Ht5sGMJaDcJZiYomSMU6CtTA==}
-    engines: {node: '>=20'}
+  '@elastic/transport@8.10.1':
+    resolution: {integrity: sha512-xo2lPBAJEt81fQRAKa9T/gUq1SPGBHpSnVUXhoSpL996fPZRAfQwFA4BZtEUQL1p8Dezodd3ZN8Wwno+mYyKuw==}
+    engines: {node: '>=18'}
 
   '@emnapi/core@1.10.0':
     resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
@@ -4906,8 +4906,8 @@ packages:
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
-  secure-json-parse@4.1.0:
-    resolution: {integrity: sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA==}
+  secure-json-parse@3.0.2:
+    resolution: {integrity: sha512-H6nS2o8bWfpFEV6U38sOSjS7bTbdgbCGU9wEM6W14P5H0QOsz94KCusifV44GpHDTu2nqZbuDNhTzu+mjDSw1w==}
 
   secure-keys@1.0.0:
     resolution: {integrity: sha512-nZi59hW3Sl5P3+wOO89eHBAAGwmCPd2aE1+dLZV5MO+ItQctIvAqihzaAXIQhvtH4KJPxM080HsnqltR2y8cWg==}
@@ -5257,10 +5257,6 @@ packages:
   undici@6.25.0:
     resolution: {integrity: sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==}
     engines: {node: '>=18.17'}
-
-  undici@7.25.0:
-    resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
-    engines: {node: '>=20.18.1'}
 
   unicode-canonical-property-names-ecmascript@2.0.1:
     resolution: {integrity: sha512-dA8WbNeb2a6oQzAQ55YlT5vQAWGV9WXOsi3SskE3bcCdM0P4SDd+24zS/OCacdRq5BkdsRj9q3Pg6YyQoxIGqg==}
@@ -6645,25 +6641,25 @@ snapshots:
 
   '@breejs/later@4.2.0': {}
 
-  '@elastic/elasticsearch@9.3.4':
+  '@elastic/elasticsearch@8.19.1':
     dependencies:
-      '@elastic/transport': 9.3.5
+      '@elastic/transport': 8.10.1
       apache-arrow: 21.1.0
       tslib: 2.8.1
     transitivePeerDependencies:
       - '@75lb/nature'
       - supports-color
 
-  '@elastic/transport@9.3.5':
+  '@elastic/transport@8.10.1':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.7.0(@opentelemetry/api@1.9.1)
       debug: 4.4.3
       hpagent: 1.2.0
       ms: 2.1.3
-      secure-json-parse: 4.1.0
+      secure-json-parse: 3.0.2
       tslib: 2.8.1
-      undici: 7.25.0
+      undici: 6.25.0
     transitivePeerDependencies:
       - supports-color
 
@@ -10049,7 +10045,7 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
-  secure-json-parse@4.1.0: {}
+  secure-json-parse@3.0.2: {}
 
   secure-keys@1.0.0: {}
 
@@ -10425,10 +10421,7 @@ snapshots:
 
   undici-types@7.16.0: {}
 
-  undici@6.25.0:
-    optional: true
-
-  undici@7.25.0: {}
+  undici@6.25.0: {}
 
   unicode-canonical-property-names-ecmascript@2.0.1: {}
 


### PR DESCRIPTION
ref [INC-275](https://app.incident.io/ghost/incidents/275)

Added a test to ensure that the major version of ElasticSearch is the one that we're currently using in production, and won't be accidentally updated by renovate.