### PR TITLE
Add zip extraction size limits

### DIFF
--- a/packages/zip/lib/extract.js
+++ b/packages/zip/lib/extract.js
@@ -2,6 +2,109 @@ const errors = require('@tryghost/errors');
 
 const defaultOptions = {};
 
+function normalizeLimit(value, fieldName) {
+    if (value === undefined || value === null || value === Infinity) {
+        return Infinity;
+    }
+
+    if (typeof value !== 'number' || !Number.isInteger(value) || value < 0) {
+        throw new errors.IncorrectUsageError({
+            message: `${fieldName} must be a non-negative integer or Infinity`,
+            context: 'Invalid zip extraction limit.',
+            code: 'INVALID_ZIP_LIMIT',
+            errorDetails: {
+                fieldName,
+                value,
+            },
+        });
+    }
+
+    return value;
+}
+
+function getLimits(options) {
+    const limits = options.limits || {};
+
+    return {
+        perEntryUncompressedBytes: normalizeLimit(
+            limits.perEntryUncompressedBytes,
+            'limits.perEntryUncompressedBytes',
+        ),
+        totalUncompressedBytes: normalizeLimit(
+            limits.totalUncompressedBytes,
+            'limits.totalUncompressedBytes',
+        ),
+    };
+}
+
+function hasSizeLimits(limits) {
+    return (
+        limits.perEntryUncompressedBytes !== Infinity || limits.totalUncompressedBytes !== Infinity
+    );
+}
+
+function getEntryUncompressedSize(entry, limits) {
+    if (
+        !hasSizeLimits(limits) &&
+        (entry.uncompressedSize === undefined || entry.uncompressedSize === null)
+    ) {
+        return 0;
+    }
+
+    if (
+        typeof entry.uncompressedSize !== 'number' ||
+        !Number.isInteger(entry.uncompressedSize) ||
+        entry.uncompressedSize < 0
+    ) {
+        throw new errors.UnsupportedMediaTypeError({
+            message: 'Zip entry has invalid uncompressed size.',
+            context: 'The zip contains an entry with invalid uncompressed size metadata.',
+            code: 'INVALID_ENTRY_SIZE',
+            errorDetails: {
+                entryName: entry.fileName,
+                observedBytes: entry.uncompressedSize,
+            },
+        });
+    }
+
+    return entry.uncompressedSize;
+}
+
+function throwOnEntryTooLarge(entry, observedBytes, limitBytes) {
+    if (observedBytes <= limitBytes) {
+        return;
+    }
+
+    throw new errors.UnsupportedMediaTypeError({
+        message: 'Zip entry exceeds maximum uncompressed size.',
+        context: 'The zip contains an entry that exceeds the maximum uncompressed size.',
+        code: 'ENTRY_TOO_LARGE',
+        errorDetails: {
+            entryName: entry.fileName,
+            observedBytes,
+            limitBytes,
+        },
+    });
+}
+
+function throwOnTotalTooLarge(entry, observedBytes, limitBytes, entriesProcessed) {
+    if (observedBytes <= limitBytes) {
+        return;
+    }
+
+    throw new errors.UnsupportedMediaTypeError({
+        message: 'Zip exceeds maximum total uncompressed size.',
+        context: 'The zip exceeds the maximum total uncompressed size.',
+        code: 'TOTAL_TOO_LARGE',
+        errorDetails: {
+            entryName: entry.fileName,
+            observedBytes,
+            limitBytes,
+            entriesProcessed,
+        },
+    });
+}
+
 function throwOnSymlinks(entry) {
     // Check if symlink
     const mode = (entry.externalFileAttributes >> 16) & 0xffff;
@@ -36,9 +139,15 @@ function throwOnLargeFilenames(entry) {
  * @param {Integer} options.defaultDirMode - Directory Mode (permissions), defaults to 0o755
  * @param {Integer} options.defaultFileMode - File Mode (permissions), defaults to 0o644
  * @param {Function} options.onEntry - if present, will be called with (entry, zipfile) for every entry in the zip
+ * @param {Object} [options.limits] - if present, sets maximum uncompressed sizes
+ * @param {Integer} options.limits.perEntryUncompressedBytes - maximum uncompressed size of each entry
+ * @param {Integer} options.limits.totalUncompressedBytes - maximum total uncompressed size across all entries
  */
-module.exports = (zipToExtract, destination, options) => {
+module.exports = async (zipToExtract, destination, options) => {
     const opts = Object.assign({}, defaultOptions, options);
+    const limits = getLimits(opts);
+    let totalUncompressedBytes = 0;
+    let entriesProcessed = 0;
 
     const extract = require('extract-zip');
 
@@ -46,6 +155,20 @@ module.exports = (zipToExtract, destination, options) => {
 
     const originalOnEntry = opts.onEntry;
     opts.onEntry = (entry, zipfile) => {
+        const entryUncompressedBytes = getEntryUncompressedSize(entry, limits);
+
+        throwOnEntryTooLarge(entry, entryUncompressedBytes, limits.perEntryUncompressedBytes);
+
+        totalUncompressedBytes += entryUncompressedBytes;
+        entriesProcessed += 1;
+
+        throwOnTotalTooLarge(
+            entry,
+            totalUncompressedBytes,
+            limits.totalUncompressedBytes,
+            entriesProcessed,
+        );
+
         throwOnSymlinks(entry);
         throwOnLargeFilenames(entry);
         if (originalOnEntry) {
@@ -53,7 +176,7 @@ module.exports = (zipToExtract, destination, options) => {
         }
     };
 
-    return extract(zipToExtract, opts).then(() => {
-        return { path: destination };
-    });
+    await extract(zipToExtract, opts);
+
+    return { path: destination };
 };

--- a/packages/zip/test/zip.test.js
+++ b/packages/zip/test/zip.test.js
@@ -9,6 +9,59 @@ const Module = require('module');
 // Mimic how we expect this to be required
 const { compress, extract } = require('../');
 
+function createZip(zipPath, addEntries) {
+    return new Promise((resolve, reject) => {
+        const output = fs.createWriteStream(zipPath);
+        const archive = archiver('zip');
+        let settled = false;
+
+        const cleanup = () => {
+            output.off('close', onClose);
+            output.off('error', onError);
+            archive.off('error', onError);
+        };
+
+        const onClose = () => {
+            if (settled) {
+                return;
+            }
+
+            settled = true;
+            cleanup();
+            resolve();
+        };
+
+        const onError = (err) => {
+            if (settled) {
+                return;
+            }
+
+            settled = true;
+            cleanup();
+            archive.abort();
+            output.destroy();
+            reject(err);
+        };
+
+        output.on('close', onClose);
+        output.on('error', onError);
+        archive.on('error', onError);
+        archive.pipe(output);
+
+        addEntries(archive);
+
+        archive.finalize();
+    });
+}
+
+function createZipWithEntries(zipPath, entries) {
+    return createZip(zipPath, (archive) => {
+        for (const entry of entries) {
+            archive.append(entry.content, { name: entry.name });
+        }
+    });
+}
+
 describe('Compress and Extract should be opposite functions', function () {
     let symlinkPath, themeFolder, zipDestination, unzipDestination;
 
@@ -128,15 +181,8 @@ describe('Extract zip', function () {
     });
 
     it('throws when the zip contains symlink entries', async function () {
-        await new Promise((resolve, reject) => {
-            const output = fs.createWriteStream(zipDestination);
-            const archive = archiver('zip');
-
-            output.on('close', resolve);
-            archive.on('error', reject);
-            archive.pipe(output);
+        await createZip(zipDestination, (archive) => {
             archive.symlink('themes/test-target', 'symlink-entry');
-            archive.finalize();
         });
 
         await assert.rejects(
@@ -156,5 +202,247 @@ describe('Extract zip', function () {
         });
 
         assert.equal(called, true);
+    });
+
+    it('preserves existing behaviour for entries without uncompressed size when no limits are configured', async function () {
+        const originalLoad = Module._load;
+        Module._load = function (request, parent, isMain) {
+            if (request === 'extract-zip') {
+                return async (zipPath, opts) => {
+                    opts.onEntry({ fileName: 'missing-size.txt', externalFileAttributes: 0 }, {});
+                };
+            }
+
+            return originalLoad(request, parent, isMain);
+        };
+
+        try {
+            const result = await extract(zipDestination, unzipDestination);
+
+            assert.equal(result.path, unzipDestination);
+        } finally {
+            Module._load = originalLoad;
+        }
+    });
+
+    it('throws when a limited entry has no uncompressed size', async function () {
+        const originalLoad = Module._load;
+        Module._load = function (request, parent, isMain) {
+            if (request === 'extract-zip') {
+                return async (zipPath, opts) => {
+                    opts.onEntry({ fileName: 'missing-size.txt', externalFileAttributes: 0 }, {});
+                };
+            }
+
+            return originalLoad(request, parent, isMain);
+        };
+
+        try {
+            await assert.rejects(
+                () =>
+                    extract(zipDestination, unzipDestination, {
+                        limits: {
+                            perEntryUncompressedBytes: 1,
+                        },
+                    }),
+                (err) => {
+                    assert.equal(err.errorType, 'UnsupportedMediaTypeError');
+                    assert.equal(err.message, 'Zip entry has invalid uncompressed size.');
+                    assert.equal(
+                        err.context,
+                        'The zip contains an entry with invalid uncompressed size metadata.',
+                    );
+                    assert.equal(err.code, 'INVALID_ENTRY_SIZE');
+                    assert.deepEqual(err.errorDetails, {
+                        entryName: 'missing-size.txt',
+                        observedBytes: undefined,
+                    });
+                    return true;
+                },
+            );
+        } finally {
+            Module._load = originalLoad;
+        }
+    });
+
+    it('throws when a limited entry has a non-numeric uncompressed size', async function () {
+        const originalLoad = Module._load;
+        Module._load = function (request, parent, isMain) {
+            if (request === 'extract-zip') {
+                return async (zipPath, opts) => {
+                    opts.onEntry(
+                        {
+                            fileName: 'invalid-size.txt',
+                            externalFileAttributes: 0,
+                            uncompressedSize: Number.NaN,
+                        },
+                        {},
+                    );
+                };
+            }
+
+            return originalLoad(request, parent, isMain);
+        };
+
+        try {
+            await assert.rejects(
+                () =>
+                    extract(zipDestination, unzipDestination, {
+                        limits: {
+                            totalUncompressedBytes: 1,
+                        },
+                    }),
+                (err) => {
+                    assert.equal(err.errorType, 'UnsupportedMediaTypeError');
+                    assert.equal(err.code, 'INVALID_ENTRY_SIZE');
+                    assert.deepEqual(err.errorDetails, {
+                        entryName: 'invalid-size.txt',
+                        observedBytes: Number.NaN,
+                    });
+                    return true;
+                },
+            );
+        } finally {
+            Module._load = originalLoad;
+        }
+    });
+
+    it('throws when an entry exceeds the per-entry uncompressed size limit', async function () {
+        await createZipWithEntries(zipDestination, [{ name: 'big-file.txt', content: '12345' }]);
+
+        await assert.rejects(
+            () =>
+                extract(zipDestination, unzipDestination, {
+                    limits: {
+                        perEntryUncompressedBytes: 4,
+                    },
+                }),
+            (err) => {
+                assert.equal(err.errorType, 'UnsupportedMediaTypeError');
+                assert.equal(err.message, 'Zip entry exceeds maximum uncompressed size.');
+                assert.equal(
+                    err.context,
+                    'The zip contains an entry that exceeds the maximum uncompressed size.',
+                );
+                assert.equal(err.code, 'ENTRY_TOO_LARGE');
+                assert.deepEqual(err.errorDetails, {
+                    entryName: 'big-file.txt',
+                    observedBytes: 5,
+                    limitBytes: 4,
+                });
+                return true;
+            },
+        );
+    });
+
+    it('throws when entries exceed the total uncompressed size limit', async function () {
+        await createZipWithEntries(zipDestination, [
+            { name: 'first-file.txt', content: '123' },
+            { name: 'second-file.txt', content: '456' },
+        ]);
+
+        await assert.rejects(
+            () =>
+                extract(zipDestination, unzipDestination, {
+                    limits: {
+                        totalUncompressedBytes: 5,
+                    },
+                }),
+            (err) => {
+                assert.equal(err.errorType, 'UnsupportedMediaTypeError');
+                assert.equal(err.message, 'Zip exceeds maximum total uncompressed size.');
+                assert.equal(err.context, 'The zip exceeds the maximum total uncompressed size.');
+                assert.equal(err.code, 'TOTAL_TOO_LARGE');
+                assert.deepEqual(err.errorDetails, {
+                    entryName: 'second-file.txt',
+                    observedBytes: 6,
+                    limitBytes: 5,
+                    entriesProcessed: 2,
+                });
+                return true;
+            },
+        );
+    });
+
+    it('extracts large entries when no limits are configured', async function () {
+        const largeFile = Buffer.alloc(1024 * 1024, 'a');
+
+        await createZipWithEntries(zipDestination, [
+            { name: 'large-file.txt', content: largeFile },
+        ]);
+
+        await extract(zipDestination, unzipDestination);
+
+        const extractedFilePath = path.join(unzipDestination, 'large-file.txt');
+        assert.equal(fs.existsSync(extractedFilePath), true);
+        assert.equal(fs.statSync(extractedFilePath).size, largeFile.length);
+    });
+
+    it('extracts large entries when limits are explicitly Infinity', async function () {
+        const largeFile = Buffer.alloc(1024 * 1024, 'a');
+
+        await createZipWithEntries(zipDestination, [
+            { name: 'large-file.txt', content: largeFile },
+        ]);
+
+        await extract(zipDestination, unzipDestination, {
+            limits: {
+                perEntryUncompressedBytes: Infinity,
+                totalUncompressedBytes: Infinity,
+            },
+        });
+
+        const extractedFilePath = path.join(unzipDestination, 'large-file.txt');
+        assert.equal(fs.existsSync(extractedFilePath), true);
+        assert.equal(fs.statSync(extractedFilePath).size, largeFile.length);
+    });
+
+    it('extracts entries within configured size limits', async function () {
+        await createZipWithEntries(zipDestination, [
+            { name: 'first-file.txt', content: '123' },
+            { name: 'second-file.txt', content: '456' },
+        ]);
+
+        await extract(zipDestination, unzipDestination, {
+            limits: {
+                perEntryUncompressedBytes: 3,
+                totalUncompressedBytes: 6,
+            },
+        });
+
+        assert.equal(fs.existsSync(path.join(unzipDestination, 'first-file.txt')), true);
+        assert.equal(fs.existsSync(path.join(unzipDestination, 'second-file.txt')), true);
+    });
+
+    it('throws when configured size limits are invalid', async function () {
+        await createZipWithEntries(zipDestination, [{ name: 'file.txt', content: '123' }]);
+
+        const invalidValues = [-1, 1.5, Number.NaN, '100'];
+        const invalidLimits = [
+            ['limits.perEntryUncompressedBytes', 'perEntryUncompressedBytes'],
+            ['limits.totalUncompressedBytes', 'totalUncompressedBytes'],
+        ].flatMap(([fieldName, limitName]) => {
+            return invalidValues.map((value) => [fieldName, value, { [limitName]: value }]);
+        });
+
+        for (const [fieldName, value, limits] of invalidLimits) {
+            await assert.rejects(
+                () => extract(zipDestination, unzipDestination, { limits }),
+                (err) => {
+                    assert.equal(err.errorType, 'IncorrectUsageError');
+                    assert.equal(
+                        err.message,
+                        `${fieldName} must be a non-negative integer or Infinity`,
+                    );
+                    assert.equal(err.context, 'Invalid zip extraction limit.');
+                    assert.equal(err.code, 'INVALID_ZIP_LIMIT');
+                    assert.deepEqual(err.errorDetails, {
+                        fieldName,
+                        value,
+                    });
+                    return true;
+                },
+            );
+        }
     });
 });


### PR DESCRIPTION
## Summary
- Add optional per-entry and total uncompressed size limits to `@tryghost/zip.extract`.
- Preserve existing behavior by defaulting omitted limits to `Infinity`.
- Cover oversized entry, oversized total, no-limit, and within-limit extraction cases.

## Testing
- `pnpm --filter @tryghost/zip test`
- `pnpm exec oxfmt -c .oxfmtrc.json --check \"packages/zip/**/*.{js,json,md}\"`