### PR TITLE
Add details to zip safety errors

### DIFF
--- a/packages/zip/lib/extract.js
+++ b/packages/zip/lib/extract.js
@@ -116,14 +116,28 @@ function throwOnSymlinks(entry) {
     if (symlink) {
         throw new errors.UnsupportedMediaTypeError({
             message: 'Symlinks are not allowed in the zip folder.',
+            context: 'The zip contains a symlink entry.',
+            code: 'SYMLINK_NOT_ALLOWED',
+            errorDetails: {
+                entryName: entry.fileName,
+            },
         });
     }
 }
 
 function throwOnLargeFilenames(entry) {
-    if (Buffer.byteLength(entry.fileName, 'utf8') >= 254) {
+    const filenameBytes = Buffer.byteLength(entry.fileName, 'utf8');
+
+    if (filenameBytes >= 254) {
         throw new errors.UnsupportedMediaTypeError({
             message: 'File names in the zip folder must be shorter than 254 characters.',
+            context: 'The zip contains a filename that is too long.',
+            code: 'FILENAME_TOO_LONG',
+            errorDetails: {
+                entryName: entry.fileName,
+                observedBytes: filenameBytes,
+                limitBytes: 254,
+            },
         });
     }
 }

--- a/packages/zip/test/zip.test.js
+++ b/packages/zip/test/zip.test.js
@@ -176,7 +176,21 @@ describe('Extract zip', function () {
         await compress(themeFolder, zipDestination);
         await assert.rejects(
             () => extract(zipDestination, unzipDestination),
-            /File names in the zip folder must be shorter than 254 characters\./,
+            (err) => {
+                assert.equal(err.errorType, 'UnsupportedMediaTypeError');
+                assert.equal(
+                    err.message,
+                    'File names in the zip folder must be shorter than 254 characters.',
+                );
+                assert.equal(err.context, 'The zip contains a filename that is too long.');
+                assert.equal(err.code, 'FILENAME_TOO_LONG');
+                assert.deepEqual(err.errorDetails, {
+                    entryName: longFileName,
+                    observedBytes: 254,
+                    limitBytes: 254,
+                });
+                return true;
+            },
         );
     });
 
@@ -187,7 +201,16 @@ describe('Extract zip', function () {
 
         await assert.rejects(
             () => extract(zipDestination, unzipDestination),
-            /Symlinks are not allowed in the zip folder\./,
+            (err) => {
+                assert.equal(err.errorType, 'UnsupportedMediaTypeError');
+                assert.equal(err.message, 'Symlinks are not allowed in the zip folder.');
+                assert.equal(err.context, 'The zip contains a symlink entry.');
+                assert.equal(err.code, 'SYMLINK_NOT_ALLOWED');
+                assert.deepEqual(err.errorDetails, {
+                    entryName: 'themes/test-target',
+                });
+                return true;
+            },
         );
     });
 


### PR DESCRIPTION
## Summary
- Add machine-readable codes and human-readable context to existing zip symlink and filename safety errors.
- Include entry name and byte details in `errorDetails` where available.
- Update tests to assert the richer Ghost error shape.

## Testing
- `pnpm --filter @tryghost/zip test`
- `pnpm exec oxfmt -c .oxfmtrc.json --check \"packages/zip/**/*.{js,json,md}\"`