### PR TITLE
Removed restrictions on major bumps in renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,10 +2,5 @@
   "extends": ["github>tryghost/renovate-config"],
   "assignees": ["9larsons"],
   "ignoreDeps": ["moment-timezone"],
-  "packageRules": [
-    {
-      "matchUpdateTypes": ["major"],
-      "automerge": false
-    }
-  ]
+  "packageRules": []
 }


### PR DESCRIPTION
no ref

This is too strict - if it passes CI, it shouldn't be blocked. Not all majors will impact our use.