### PR TITLE
Added Bree worker options to job manager

### DIFF
--- a/packages/job-manager/lib/JobManager.js
+++ b/packages/job-manager/lib/JobManager.js
@@ -44,8 +44,15 @@ class JobManager {
      * @param {Function} [options.workerMessageHandler] - custom message handler coming from workers
      * @param {Object} [options.JobModel] - a model which can persist job data in the storage
      * @param {Object} [options.domainEvents] - domain events emitter
+     * @param {Object} [options.worker] - default Bree worker options
      */
-    constructor({ errorHandler, workerMessageHandler, JobModel, domainEvents }) {
+    constructor({
+        errorHandler,
+        workerMessageHandler,
+        JobModel,
+        domainEvents,
+        worker: workerOptions,
+    }) {
         this.inlineQueue = fastq(this, worker, 3);
         this._jobMessageHandler = this._jobMessageHandler.bind(this);
         this._jobErrorHandler = this._jobErrorHandler.bind(this);
@@ -72,6 +79,7 @@ class JobManager {
             logger: logging,
             errorHandler: combinedErrorHandler,
             workerMessageHandler: combinedMessageHandler,
+            worker: workerOptions,
         });
 
         this.bree.on('worker created', (name) => {

--- a/packages/job-manager/test/job-manager.test.js
+++ b/packages/job-manager/test/job-manager.test.js
@@ -54,6 +54,22 @@ describe('Job Manager', function () {
         assert.notEqual(jobManager.inlineJobHandler, undefined);
     });
 
+    it('passes default worker options to Bree', function () {
+        const worker = {
+            execArgv: ['--import', 'file:///tmp/loader.mjs'],
+            resourceLimits: {
+                maxOldGenerationSizeMb: 256,
+            },
+        };
+
+        jobManager = new JobManager({
+            config: stubConfig,
+            worker,
+        });
+
+        assert.deepEqual(jobManager.bree.config.worker, worker);
+    });
+
     describe('Add a job', function () {
         describe('Inline jobs', function () {
             it('adds a job to a queue', async function () {


### PR DESCRIPTION
## Summary
- adds a JobManager constructor option for default Bree worker options
- forwards the option into Bree so consumers can configure offloaded worker threads without monkey-patching worker_threads
- adds coverage for the pass-through config

## Testing
- pnpm --dir /Users/slars/dev/framework --filter @tryghost/job-manager lint
- pnpm --dir /Users/slars/dev/framework format:check
- pnpm --dir /Users/slars/dev/framework --filter @tryghost/job-manager test

Note: the job-manager test command exits successfully with all tests passing, but Vitest still reports an existing unhandled rejection from test/jobs/timed-job.js while running "gracefully shuts down an interval job".