### PR TITLE
Skip already-published packages in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -71,8 +71,30 @@ jobs:
           npm config get registry
           npm config get @tryghost:registry
 
+      - name: Determine packages to publish
+        id: pubs
+        run: |
+          to_publish=()
+          for pkg in packages/*/package.json; do
+            name=$(jq -r .name "$pkg")
+            version=$(jq -r .version "$pkg")
+            if [ -n "$(npm view "$name@$version" version 2>/dev/null)" ]; then
+              echo "skip $name@$version (already published)"
+            else
+              echo "queue $name@$version"
+              to_publish+=("$name")
+            fi
+          done
+          if [ ${#to_publish[@]} -eq 0 ]; then
+            echo "nothing to publish"
+            echo "projects=" >> "$GITHUB_OUTPUT"
+          else
+            (IFS=,; echo "projects=${to_publish[*]}") >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Publish to npm
-        run: npx nx release publish ${{ (github.event.inputs['dry-run'] == 'true' && '--dry-run') || '' }}
+        if: steps.pubs.outputs.projects != ''
+        run: npx nx release publish --projects=${{ steps.pubs.outputs.projects }} ${{ (github.event.inputs['dry-run'] == 'true' && '--dry-run') || '' }}
 
       - uses: tryghost/actions/actions/slack-build@128d496a57fb11e44e97d690f0d5381c58e52489 # main
         if: failure()


### PR DESCRIPTION
## Summary
- Pre-check each `packages/*/package.json` against the npm registry and only invoke `nx release publish` for versions that aren't there yet. Skip the publish step entirely when nothing needs to ship.
- Makes re-runs of the publish workflow a no-op for versions that already landed, instead of guaranteed-failing with Rekor 409s.

## Background
Run [26455592686](https://github.com/TryGhost/framework/actions/runs/26455592686) failed both attempts. Investigation showed two distinct failure modes, both surfaced as `TLOG_CREATE_ENTRY_ERROR`:

1. **Attempt 1 (spurious 409s on fresh versions):** Sigstore's tlog was flaky during that window (a bare `502 Bad Gateway` from Rekor leaked through in attempt 2 as direct evidence). sigstore-js retries transient errors internally; the retry's signed payload is identical to the original, so Rekor's idempotency check returns 409 — even though no Rekor entry from us existed beforehand. `npm view <pkg>@<version> time` confirms the failing versions weren't on npm before attempt 1 started.
2. **Attempt 2 (real 409s on previously-published versions):** The 7 packages that did land in attempt 1 produced byte-identical tarballs on retry, hence identical Rekor entries, hence legitimate 409s.

In both cases `nx release publish` defaults to `--nx-bail=true`, so the first failure stopped scheduling and only the already-in-flight tasks drained.

## The fix
Pre-check via `npm view <name>@<version>` for each package, collect the still-missing names, and pass them to `nx release publish --projects=...`. If everything's already on npm the publish step is skipped via an `if:` guard.

This avoids the legitimate-409 case entirely (the load-bearing one — every re-run was guaranteed to hit it) and leaves the rare spurious-409 case to be cleaned up by re-running the workflow, since the new run's provenance metadata (different attempt) produces a different Rekor payload.

## Test plan
- [ ] Smoke test via ad-hoc dispatch from this branch: `gh workflow run publish.yml --ref publish-skip-already-published -f dry-run=false`. Expected: every still-published-on-main package logs `skip … (already published)`; the missing ones (currently ~12 from the failed run, per local dry-run) actually publish.
- [ ] Verify the publish step is skipped entirely when nothing needs to ship.
- [ ] After merge, confirm the next "Published new versions" commit runs clean end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)