### PR TITLE
Updated @tryghost/nql to 0.13.0

### DIFF
--- a/packages/bookshelf-filter/package.json
+++ b/packages/bookshelf-filter/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "@tryghost/debug": "workspace:*",
     "@tryghost/errors": "workspace:*",
-    "@tryghost/nql": "0.12.11",
+    "@tryghost/nql": "0.13.0",
     "@tryghost/tpl": "workspace:*"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -119,8 +119,8 @@ importers:
         specifier: workspace:*
         version: link:../errors
       '@tryghost/nql':
-        specifier: 0.12.11
-        version: 0.12.11(supports-color@7.2.0)
+        specifier: 0.13.0
+        version: 0.13.0
       '@tryghost/tpl':
         specifier: workspace:*
         version: link:../tpl
@@ -2311,8 +2311,8 @@ packages:
   '@tryghost/bunyan-rotating-filestream@0.0.7':
     resolution: {integrity: sha512-dswM+dxG8J7WpVoSjzAdoWXqqB5Dg0C2T7Zh6eoUvl5hkA8yWWJi/fS4jNXlHF700lWQ0g8/t+leJ7SGSWd+aw==}
 
-  '@tryghost/mongo-knex@0.9.5':
-    resolution: {integrity: sha512-etO6Kz8a1dgMV6yapD2C2JsoeLrUjkIoIUdXrkV9ELHQsMjMhtI2SAUnMV9AcLhxv0P7h8UWWD2rlNBwo8JJig==}
+  '@tryghost/mongo-knex@0.10.0':
+    resolution: {integrity: sha512-m9yvVWbJHfZpPi6R0as1RfRu7bPJwhf9j4ZHF1hEZWJgRKfycSH8wUKvK7eS45fxINicEk2CXSFMRDd4IM6N2Q==}
 
   '@tryghost/mongo-utils@0.6.4':
     resolution: {integrity: sha512-4ZGl9QXoMTQb9qb5HGjMjVLkV39FO0F/0cM4Z3i/9gUXXfdmGZwPdcAMBRT7oRhqng3/4uSRpvQ/Rk0oASM+kg==}
@@ -2320,8 +2320,8 @@ packages:
   '@tryghost/nql-lang@0.6.5':
     resolution: {integrity: sha512-13Loz2yH7GCMAfpVawD6KNWNPIVTc4STnP+MeCwbrWg8htv/CPOB0u+i9Eap0qEi8h6TC2aoOvbQV0EvjidQaQ==}
 
-  '@tryghost/nql@0.12.11':
-    resolution: {integrity: sha512-8Cb10OpQWT+v0Xvfrov9IkBwzyPlARsjF1EIC8f3ET/JZD3G+ARoQ3GEBQ7XeW6YcUd7MIh3zqJTv5ST+aDjZA==}
+  '@tryghost/nql@0.13.0':
+    resolution: {integrity: sha512-Aa2vJBPBK5WltmO4ifkeNNG/XedmyeN9B0CT4HLHEIjUARc8wKKntzmRtzSJCSL5moyX40vJ95yTnUNwA1wxew==}
 
   '@tryghost/string@0.3.5':
     resolution: {integrity: sha512-Ov2UYOuU5QutDo/UECtkhHR3jdT4R/aNxzKFk0iaH0yiwxLnlqEB4QBBVnYYIN8zECNAazRzkygtdFSlSkuaoA==}
@@ -7020,7 +7020,7 @@ snapshots:
     dependencies:
       long-timeout: 0.1.1
 
-  '@tryghost/mongo-knex@0.9.5(supports-color@7.2.0)':
+  '@tryghost/mongo-knex@0.10.0':
     dependencies:
       debug: 4.4.3(supports-color@7.2.0)
       lodash: 4.18.1
@@ -7035,9 +7035,9 @@ snapshots:
     dependencies:
       date-fns: 2.30.0
 
-  '@tryghost/nql@0.12.11(supports-color@7.2.0)':
+  '@tryghost/nql@0.13.0':
     dependencies:
-      '@tryghost/mongo-knex': 0.9.5(supports-color@7.2.0)
+      '@tryghost/mongo-knex': 0.10.0
       '@tryghost/mongo-utils': 0.6.4
       '@tryghost/nql-lang': 0.6.5
       lodash: 4.18.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,6 +10,9 @@ allowBuilds:
   nx: true
   sqlite3: true
 minimumReleaseAge: 1440
+minimumReleaseAgeExclude:
+  - '@tryghost/mongo-knex'
+  - '@tryghost/nql'
 catalog:
   sinon: 22.0.0
   typescript: 6.0.3


### PR DESCRIPTION
Bumps `@tryghost/nql` 0.12.11 → 0.13.0 in `bookshelf-filter`, which pulls in `@tryghost/mongo-knex` 0.10.0 transitively (it's not a direct dependency anywhere in this repo).

Both versions were published within the 24h `minimumReleaseAge` window so installs were blocked — added a targeted `minimumReleaseAgeExclude` for these two first-party packages rather than loosening the global policy.