### PR TITLE
Fixed phantom @tryghost/* dependencies in nodemailer and domain-events

### DIFF
--- a/packages/domain-events/package.json
+++ b/packages/domain-events/package.json
@@ -22,7 +22,7 @@
     "test": "NODE_ENV=testing vitest run --coverage",
     "lint": "oxlint -c ../../.oxlintrc.json ."
   },
-  "devDependencies": {
+  "dependencies": {
     "@tryghost/logging": "workspace:*"
   }
 }

--- a/packages/nodemailer/package.json
+++ b/packages/nodemailer/package.json
@@ -25,6 +25,7 @@
   "dependencies": {
     "@aws-sdk/client-sesv2": "3.1067.0",
     "@tryghost/errors": "workspace:*",
+    "@tryghost/tpl": "workspace:*",
     "nodemailer": "8.0.11",
     "nodemailer-mailgun-transport": "2.1.5",
     "nodemailer-stub-transport": "1.1.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -264,7 +264,7 @@ importers:
         version: 4.4.3(supports-color@7.2.0)
 
   packages/domain-events:
-    devDependencies:
+    dependencies:
       '@tryghost/logging':
         specifier: workspace:*
         version: link:../logging
@@ -519,6 +519,9 @@ importers:
       '@tryghost/errors':
         specifier: workspace:*
         version: link:../errors
+      '@tryghost/tpl':
+        specifier: workspace:*
+        version: link:../tpl
       nodemailer:
         specifier: 8.0.11
         version: 8.0.11


### PR DESCRIPTION
## Summary

Two `@tryghost/*` packages `require()` an internal `@tryghost/*` package at runtime without declaring it as a `dependency`. They resolve today only by accident of pnpm hoisting from a consumer (e.g. `ghost/core`), which is fragile:

- **`@tryghost/nodemailer`** — `lib/nodemailer.js` does `require('@tryghost/tpl')` (used for the `unknownTransport` error message) but `@tryghost/tpl` was not in `dependencies`.
- **`@tryghost/domain-events`** — `lib/DomainEvents.js` does `require('@tryghost/logging')`, but `@tryghost/logging` was declared only under `devDependencies`.

Both are now declared as `workspace:*` runtime dependencies.

## Why this matters

Any time the hoist tree is incomplete — e.g. an incremental `pnpm install` over a branch switch — the undeclared dep can be missing from `.pnpm/node_modules`, and Node's resolution walk fails with `Cannot find module '@tryghost/tpl'` (requireStack → `@tryghost/nodemailer/lib/nodemailer.js`). In Ghost that fails the mail-service boot, taking down the whole server, so every DB-backed test fails to boot until a clean reinstall re-hoists it. `pnpm install --force` does **not** fix it (it only checks the lockfile hash, not hoist completeness). Declaring the deps explicitly makes resolution deterministic for downstream consumers.

## Scope / audit

Per the linked issue I audited every package's non-test source for `require()`/`import` of an undeclared `@tryghost/*`. These two were the only genuine offenders; all other cross-package requires are already declared.

## Testing

- `pnpm install --frozen-lockfile` passes (lockfile diff limited to the two importer entries — both internal `link:` references, no new resolved packages).
- `@tryghost/nodemailer` and `@tryghost/domain-events` test + lint suites pass (100% coverage retained).

ref https://linear.app/ghost/issue/PLA-155