### PR TITLE
Renamed CI gate job to the org-standard "Required checks pass"

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,17 +65,13 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
-  test-results:
+  required-checks-pass:
     runs-on: ubuntu-latest
-    name: All tests pass
+    name: Required checks pass
     permissions: {}
     needs: [test]
     if: always()
     steps:
-      - run: |
-          result="${{ needs.test.result }}"
-          if [[ $result == "success" || $result == "skipped" ]]; then
-            exit 0
-          else
-            exit 1
-          fi
+      - name: Verify all required jobs succeeded
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: exit 1


### PR DESCRIPTION
## Why

Branch protection on this repo currently requires a status check named exactly `All tests pass` — the legacy gate job in `test.yml`. Requiring individual or repo-specific check names couples branch protection to the CI matrix: rename the job or restructure the workflow and the required check silently stops existing, blocking every PR.

The org is standardizing every repo on one stable aggregator check: a gate job whose name (and therefore check context) is exactly `Required checks pass`.

## What

- Renamed the `test-results` gate job to id `required-checks-pass` / name `Required checks pass`.
- Coverage is unchanged: `needs: [test]` still covers every job in the workflow, `if: always()` retained.
- The pass/fail step now uses the shared shape (`contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')`), which preserves the old gate's pass-on-skipped behaviour.
- No action versions, matrix entries, or other CI behaviour changed. Top-level `permissions: contents: read` was already present.

## Ruleset

The branch ruleset is being updated in the same pass to require `Required checks pass` instead of `All tests pass`, so this PR must go green on the new gate before merging.