### PR TITLE
Added @tryghost/bunyan-rotating-filestream package to the monorepo

### DIFF
--- a/packages/bunyan-rotating-filestream/LICENSE
+++ b/packages/bunyan-rotating-filestream/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2013-2026 Ghost Foundation
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/bunyan-rotating-filestream/README.md
+++ b/packages/bunyan-rotating-filestream/README.md
@@ -1,0 +1,64 @@
+# Bunyan Rotating Filestream
+
+## Install
+
+`npm install @tryghost/bunyan-rotating-filestream --save`
+
+or
+
+`pnpm add @tryghost/bunyan-rotating-filestream`
+
+## Purpose
+
+A rotating file stream for the [bunyan](https://github.com/trentm/node-bunyan) logger, supporting period-based and size-based rotation, gzip compression of archives, and limits on the number and total size of archived files.
+
+## Usage
+
+Create a bunyan logger using the stream:
+
+```js
+const log = bunyan.createLogger({
+    name: 'foo',
+    streams: [
+        {
+            stream: new RotatingFileStream({
+                path: '/var/log/foo.log',
+                period: '1d', // daily rotation
+                totalFiles: 10, // keep up to 10 backup copies
+                rotateExisting: true, // Give ourselves a clean file when we start up, based on period
+                threshold: '10m', // Rotate log files larger than 10 megabytes
+                totalSize: '20m', // Don't keep more than 20mb of archived log files
+                gzip: true, // Compress the archive log files to save space
+            }),
+        },
+    ],
+});
+```
+
+Other options include `startNewFile` to always open a new file on start-up.
+
+## Develop
+
+This is a mono repository, managed with [Nx](https://nx.dev).
+
+Follow the instructions for the top-level repo.
+
+1. `git clone` this repo & `cd` into it as usual
+2. Run `pnpm install` to install top-level dependencies.
+
+## Run
+
+- `pnpm dev`
+
+## Test
+
+- `pnpm lint` runs oxlint
+- `pnpm test` runs lint and tests
+
+## Credit
+
+Many thanks to @Rcomian for their work on the original bunyan-rotating-file-stream project, this project borrows lots of the code and all of the ideas in the original.
+
+# Copyright & License
+
+Copyright (c) 2013-2026 Ghost Foundation - Released under the [MIT license](LICENSE).

--- a/packages/bunyan-rotating-filestream/index.js
+++ b/packages/bunyan-rotating-filestream/index.js
@@ -1,0 +1,86 @@
+const WriteQueue = require('./lib/writeQueue');
+const PeriodTrigger = require('./lib/periodTrigger');
+const ThresholdTrigger = require('./lib/thresholdTrigger');
+const FileRotator = require('./lib/fileRotator');
+const { BytesWritten, Rotate, NewFile } = require('./lib/customEvents');
+
+const fileStreams = [];
+
+class RotatingFileStream {
+    constructor(config) {
+        if (typeof config.path !== 'string') {
+            throw new Error('Must provide a string for path');
+        }
+        if (fileStreams.indexOf(config.path) >= 0) {
+            throw new Error('Rotating log already exists for path: ', config.path);
+        }
+        fileStreams.push(config.path);
+        this._path = config.path;
+        this._rotator = new FileRotator(config);
+        this._queue = new WriteQueue();
+        this._triggers = [];
+        if (config.period) {
+            const periodTrigger = new PeriodTrigger(config.period, config.rotateExisting);
+            this._triggers.push(periodTrigger);
+        }
+        if (config.threshold) {
+            const thresholdTrigger = new ThresholdTrigger(config.threshold);
+            this._queue.on(BytesWritten, (bytes) => thresholdTrigger.updateWritten(bytes));
+            this._triggers.push(thresholdTrigger);
+        }
+        this._rotatingLock = false;
+        this._triggers.forEach((trigger) => {
+            trigger.on(Rotate, () => {
+                this._rotate();
+            });
+        });
+        this._rotator.on(NewFile, (fileInfo) => {
+            this._queue.setFileHandle(this._rotator.getCurrentHandle());
+            this._triggers.forEach((trigger) => trigger.newFile(fileInfo));
+        });
+        this._initialised = this._rotator.initialise();
+    }
+
+    async _rotate() {
+        if (this._rotatingLock) {
+            // Already rotating
+            return;
+        }
+        this._rotatingLock = true;
+        this._rotating = (async () => {
+            await this._queue.pause();
+            const nextFileHandle = await this._rotator.rotate();
+            this._queue.setFileHandle(nextFileHandle);
+            this._rotatingLock = false;
+        })();
+        await this._rotating;
+    }
+
+    async write(data) {
+        this._queue.push(data);
+    }
+
+    async end() {
+        await this._initialised;
+        // Stop triggers first so no new rotation can start, then wait for any
+        // in-flight rotation before closing the file handles
+        this._triggers.forEach((trigger) => trigger.shutdown());
+        await this._rotating;
+        await this._queue.shutdown();
+        await this._rotator.shutdown();
+        const fileStreamIndex = fileStreams.indexOf(this._path);
+        if (fileStreamIndex >= 0) {
+            fileStreams.splice(fileStreamIndex, 1);
+        }
+    }
+
+    destroy() {
+        this.end();
+    }
+
+    destroySoon() {
+        this.end();
+    }
+}
+
+module.exports = RotatingFileStream;

--- a/packages/bunyan-rotating-filestream/index.js
+++ b/packages/bunyan-rotating-filestream/index.js
@@ -29,6 +29,7 @@ class RotatingFileStream {
             this._triggers.push(thresholdTrigger);
         }
         this._rotatingLock = false;
+        this._closed = false;
         this._triggers.forEach((trigger) => {
             trigger.on(Rotate, () => {
                 this._rotate();
@@ -42,8 +43,8 @@ class RotatingFileStream {
     }
 
     async _rotate() {
-        if (this._rotatingLock) {
-            // Already rotating
+        if (this._rotatingLock || this._closed) {
+            // Already rotating or shutting down
             return;
         }
         this._rotatingLock = true;
@@ -61,6 +62,9 @@ class RotatingFileStream {
     }
 
     async end() {
+        // Block new rotations immediately - the threshold trigger has no timer
+        // to shut down and can still fire while the queue drains below
+        this._closed = true;
         await this._initialised;
         // Stop triggers first so no new rotation can start, then wait for any
         // in-flight rotation before closing the file handles

--- a/packages/bunyan-rotating-filestream/lib/customEvents.js
+++ b/packages/bunyan-rotating-filestream/lib/customEvents.js
@@ -1,0 +1,8 @@
+module.exports = {
+    // Emitted when a new rotation is needed
+    Rotate: Symbol('rotate'),
+    // Emitted when a new file handle is acquired with the file info
+    NewFile: Symbol('newFile'),
+    // Emitted whenever data is written to the file with the number of bytes
+    BytesWritten: Symbol('bytesWritten'),
+};

--- a/packages/bunyan-rotating-filestream/lib/fileRotator.js
+++ b/packages/bunyan-rotating-filestream/lib/fileRotator.js
@@ -1,0 +1,183 @@
+const zlib = require('zlib');
+const { pipeline } = require('stream');
+const { promisify } = require('util');
+const { createReadStream, createWriteStream } = require('fs');
+const fs = require('fs').promises;
+const pipe = promisify(pipeline);
+const path = require('path');
+const { processSize } = require('../util/configProcessors');
+
+const { EventEmitter } = require('events');
+const { NewFile } = require('./customEvents');
+
+class FileRotator extends EventEmitter {
+    constructor(config) {
+        super();
+        this._startNewFile = config.startNewFile;
+        this._totalFiles = config.totalFiles;
+        this._totalSize = processSize(config.totalSize);
+        this._gzip = config.gzip;
+        this._path = config.path;
+        this._initialised = false;
+        this._currentHandle = null;
+    }
+
+    async initialise() {
+        if (this._initialised) {
+            return;
+        }
+        this._initialised = true;
+
+        await this._deleteFiles();
+        if (this._startNewFile) {
+            await this.rotate();
+        } else {
+            // Will open existing rather than immediately rotate
+            await this._initialiseNewFile();
+        }
+    }
+
+    getCurrentHandle() {
+        return this._currentHandle;
+    }
+
+    async rotate() {
+        if (this._currentHandle) {
+            await this._closeFileHandle();
+            this._currentHandle = null;
+        }
+        if (this._gzip) {
+            await this._gzipCurrentFile();
+        }
+        await this._deleteFiles();
+        await this._moveIntermediateFiles();
+        await this._initialiseNewFile();
+        // Set by _initialiseNewFile
+        return this._currentHandle;
+    }
+
+    async shutdown() {
+        if (this._currentHandle) {
+            await this._closeFileHandle();
+            this._currentHandle = null;
+        }
+    }
+
+    async _initialiseNewFile() {
+        this._currentHandle = await fs.open(this._getFileName(0, false), 'a');
+        const fileInfo = await this._currentHandle.stat();
+        this.emit(NewFile, fileInfo);
+        return this._currentHandle;
+    }
+
+    async _gzipCurrentFile() {
+        const inputName = this._getFileName(0, false);
+        const outputName = this._getFileName(0, true);
+
+        try {
+            await fs.stat(inputName);
+        } catch (err) {
+            if (err.code === 'ENOENT') {
+                return;
+            } else {
+                throw err;
+            }
+        }
+
+        const gzip = zlib.createGzip();
+        const source = createReadStream(inputName);
+        const destination = createWriteStream(outputName);
+        await pipe(source, gzip, destination);
+        source.close();
+        destination.close();
+        await fs.unlink(inputName);
+    }
+
+    _getFileName(number, gzip) {
+        const parsedPath = path.parse(this._path);
+        let base = `${parsedPath.name}.${String(number - 1)}${parsedPath.ext}`;
+        if (number === 0) {
+            base =
+                parsedPath.name
+                    .replace('.%N', '')
+                    .replace('_%N', '')
+                    .replace('-%N', '')
+                    .replace('%N', '') + parsedPath.ext;
+        } else if (parsedPath.name.indexOf('%N') >= 0) {
+            base = parsedPath.name.replace('%N', String(number - 1)) + parsedPath.ext;
+        }
+
+        const isGzip = this._gzip && gzip;
+        if (isGzip) {
+            base += '.gz';
+        }
+
+        return path.join(parsedPath.dir, base);
+    }
+
+    async _deleteFiles() {
+        const filesToDelete = [];
+        // Only count backups - start at file 1 to ignore current file
+        let fileNumber = 1;
+        let bytesTotal = 0;
+        for (; ; fileNumber++) {
+            const name = this._getFileName(fileNumber, true);
+            try {
+                const result = await fs.stat(name);
+                bytesTotal += result.size;
+                if (
+                    (this._totalSize && bytesTotal > this._totalSize) ||
+                    (this._totalFiles && fileNumber >= this._totalFiles)
+                ) {
+                    filesToDelete.push(name);
+                }
+            } catch (err) {
+                if (err.code === 'ENOENT') {
+                    break;
+                } else {
+                    throw err;
+                }
+            }
+        }
+        for (const file of filesToDelete) {
+            await fs.unlink(file);
+        }
+    }
+
+    async _moveIntermediateFiles() {
+        const filesToMove = [];
+        let fileNumber = 0;
+        for (; ; fileNumber++) {
+            const name = this._getFileName(fileNumber, true);
+            try {
+                const result = await fs.stat(name);
+                filesToMove.push(result);
+            } catch (err) {
+                if (err.code === 'ENOENT') {
+                    break;
+                } else {
+                    throw err;
+                }
+            }
+        }
+        // Set to last file in sequence
+        fileNumber -= 1;
+        while (fileNumber >= 0) {
+            await fs.rename(
+                this._getFileName(fileNumber, true),
+                this._getFileName(fileNumber + 1, true),
+            );
+            fileNumber -= 1;
+        }
+    }
+
+    async _closeFileHandle() {
+        if (this._currentHandle) {
+            const closePromise = this._currentHandle.close();
+            this._currentHandle = null;
+            await closePromise;
+        }
+    }
+}
+
+module.exports = FileRotator;

--- a/packages/bunyan-rotating-filestream/lib/periodTrigger.js
+++ b/packages/bunyan-rotating-filestream/lib/periodTrigger.js
@@ -1,0 +1,125 @@
+const { EventEmitter } = require('events');
+const { Rotate } = require('./customEvents');
+const { processPeriod } = require('../util/configProcessors');
+const { setTimeout, clearTimeout } = require('long-timeout');
+
+const getNextRotation = (period, lastRotation) => {
+    var date = new Date();
+
+    let nextRotation;
+    switch (period.unit) {
+        case 'ms':
+            // Hidden millisecond period for debugging.
+            if (lastRotation) {
+                nextRotation = lastRotation + period.num;
+            } else {
+                nextRotation = Date.now() + period.num;
+            }
+            break;
+        case 'h':
+            if (lastRotation) {
+                nextRotation = lastRotation + period.num * 60 * 60 * 1000;
+            } else {
+                // First time: top of the next hour.
+                nextRotation = Date.UTC(
+                    date.getUTCFullYear(),
+                    date.getUTCMonth(),
+                    date.getUTCDate(),
+                    date.getUTCHours() + 1,
+                );
+            }
+            break;
+        case 'd':
+            if (lastRotation) {
+                nextRotation = lastRotation + period.num * 24 * 60 * 60 * 1000;
+            } else {
+                // First time: start of tomorrow (i.e. at the coming midnight) UTC.
+                nextRotation = Date.UTC(
+                    date.getUTCFullYear(),
+                    date.getUTCMonth(),
+                    date.getUTCDate() + 1,
+                );
+            }
+            break;
+        case 'w':
+            // Currently, always on Sunday morning at 00:00:00 (UTC).
+            if (lastRotation) {
+                nextRotation = lastRotation + period.num * 7 * 24 * 60 * 60 * 1000;
+            } else {
+                // First time: this coming Sunday.
+                nextRotation = Date.UTC(
+                    date.getUTCFullYear(),
+                    date.getUTCMonth(),
+                    date.getUTCDate() + (7 - date.getUTCDay()),
+                );
+            }
+            break;
+        case 'm':
+            if (lastRotation) {
+                nextRotation = Date.UTC(date.getUTCFullYear(), date.getUTCMonth() + period.num, 1);
+            } else {
+                // First time: the start of the next month.
+                nextRotation = Date.UTC(date.getUTCFullYear(), date.getUTCMonth() + 1, 1);
+            }
+            break;
+        case 'y':
+            if (lastRotation) {
+                nextRotation = Date.UTC(date.getUTCFullYear() + period.num, 0, 1);
+            } else {
+                // First time: the start of the next year.
+                nextRotation = Date.UTC(date.getUTCFullYear() + 1, 0, 1);
+            }
+            break;
+        default:
+            throw new Error(`Invalid period scope: "${period.unit}"`);
+    }
+
+    return nextRotation;
+};
+
+class PeriodTrigger extends EventEmitter {
+    constructor(period, rotateExisting) {
+        super();
+        this._period = processPeriod(period);
+        this._rotateExisting = rotateExisting;
+        this._task = null;
+        this._rotateAt = null;
+    }
+
+    newFile(fileInfo) {
+        if (this._rotateExisting) {
+            this._rotateAt = fileInfo.birthtimeMs;
+            // Only rotate based on the first file once
+            this._rotateExisting = false;
+        }
+        this.setNextTask();
+    }
+
+    shutdown() {
+        if (this._task) {
+            clearTimeout(this._task);
+        }
+    }
+
+    setNextTask() {
+        if (this._task) {
+            clearTimeout(this._task);
+        }
+        this._rotateAt = getNextRotation(this._period, this._rotateAt);
+        this._task = setTimeout(
+            () => {
+                this._emitRotate();
+                this.setNextTask();
+            },
+            Math.max(this._rotateAt - Date.now(), 0),
+        );
+        // Prevent timeout from keeping Node.js alive
+        this._task.unref();
+    }
+
+    _emitRotate() {
+        this.emit(Rotate);
+    }
+}
+
+module.exports = PeriodTrigger;

--- a/packages/bunyan-rotating-filestream/lib/thresholdTrigger.js
+++ b/packages/bunyan-rotating-filestream/lib/thresholdTrigger.js
@@ -1,0 +1,32 @@
+const { EventEmitter } = require('events');
+const { Rotate } = require('./customEvents');
+const { processSize } = require('../util/configProcessors');
+
+class ThresholdTrigger extends EventEmitter {
+    constructor(threshold) {
+        super();
+        this._threshold = processSize(threshold);
+        this._totalWritten = 0;
+    }
+
+    newFile(fileInfo) {
+        this._totalWritten = fileInfo.size;
+        if (this._totalWritten > this.threshold) {
+            // Case where initial file is larger than threshold - usually on config change between boots
+            this.emit(Rotate);
+        }
+    }
+
+    updateWritten(bytes) {
+        this._totalWritten += bytes;
+        if (this._totalWritten > this._threshold) {
+            this.emit(Rotate);
+        }
+    }
+
+    shutdown() {
+        // no-op
+    }
+}
+
+module.exports = ThresholdTrigger;

--- a/packages/bunyan-rotating-filestream/lib/writeQueue.js
+++ b/packages/bunyan-rotating-filestream/lib/writeQueue.js
@@ -1,0 +1,52 @@
+const { EventEmitter } = require('events');
+const { BytesWritten } = require('./customEvents');
+
+class WriteQueue extends EventEmitter {
+    constructor() {
+        super();
+        this._events = [];
+        this._fileHandle = null;
+        this._paused = true;
+        this._isWriting = false;
+        this._writing = Promise.resolve(true);
+    }
+
+    setFileHandle(fileHandle) {
+        this._fileHandle = fileHandle;
+        this._paused = false;
+    }
+
+    async _write(amount) {
+        const data = this._events.splice(0, amount).join('');
+        const result = await this._fileHandle.write(data);
+        this.emit(BytesWritten, result.bytesWritten);
+        this._isWriting = false;
+    }
+
+    push(event) {
+        this._events.push(event);
+        if (!this._paused && !this._isWriting) {
+            this.flushToDisk();
+        }
+    }
+
+    flushToDisk() {
+        const currentEventCount = this._events.length;
+        this._isWriting = true;
+        this._writing = this._write(currentEventCount);
+    }
+
+    async pause() {
+        this._paused = true;
+        await this._writing;
+    }
+
+    async shutdown() {
+        if (!this._paused) {
+            this.flushToDisk();
+        }
+        await this.pause();
+    }
+}
+
+module.exports = WriteQueue;

--- a/packages/bunyan-rotating-filestream/package.json
+++ b/packages/bunyan-rotating-filestream/package.json
@@ -1,16 +1,17 @@
 {
-  "name": "@tryghost/logging",
-  "version": "5.1.1",
+  "name": "@tryghost/bunyan-rotating-filestream",
+  "version": "0.0.7",
   "license": "MIT",
   "author": "Ghost Foundation",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/TryGhost/framework.git",
-    "directory": "packages/logging"
+    "directory": "packages/bunyan-rotating-filestream"
   },
   "files": [
     "index.js",
-    "lib"
+    "lib",
+    "util"
   ],
   "main": "index.js",
   "publishConfig": {
@@ -23,19 +24,10 @@
     "posttest": "pnpm run lint"
   },
   "dependencies": {
-    "@tryghost/bunyan-rotating-filestream": "workspace:*",
-    "@tryghost/elasticsearch": "workspace:*",
-    "@tryghost/http-stream": "workspace:*",
-    "@tryghost/pretty-stream": "workspace:*",
-    "@tryghost/root-utils": "workspace:*",
-    "bunyan": "1.8.15",
-    "fs-extra": "11.3.6",
-    "gelf-stream": "1.1.1",
-    "json-stringify-safe": "5.0.1",
-    "lodash": "4.18.1"
+    "long-timeout": "0.1.1"
   },
   "devDependencies": {
-    "@tryghost/errors": "workspace:*",
+    "bunyan": "1.8.15",
     "sinon": "catalog:"
   }
 }

--- a/packages/bunyan-rotating-filestream/test/filerotate.test.js
+++ b/packages/bunyan-rotating-filestream/test/filerotate.test.js
@@ -1,0 +1,106 @@
+const sinon = require('sinon');
+const assert = require('assert');
+const sandbox = sinon.createSandbox();
+const bunyan = require('bunyan');
+const path = require('path');
+
+const RotatingFileStream = require('../index');
+const fs = require('fs').promises;
+const testConfig = {
+    path: 'logs/foo.log',
+    totalFiles: 10,
+    threshold: '1k',
+    rotateExisting: true,
+    gzip: true,
+};
+
+function delay(ms) {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+describe('RotatingFileStream', function () {
+    beforeAll(async function () {
+        await fs.mkdir(path.parse(testConfig.path).dir, {
+            recursive: true,
+        });
+    });
+
+    afterEach(function () {
+        sandbox.restore();
+    });
+
+    it('Processes client configuration', async function () {
+        const rfs = new RotatingFileStream(testConfig);
+        assert.strictEqual(rfs._path, testConfig.path);
+        await rfs.end();
+    });
+
+    it('Writes log files', async function () {
+        const stream = new RotatingFileStream(testConfig);
+        const logger = bunyan.createLogger({
+            name: 'foo',
+            streams: [
+                {
+                    stream,
+                },
+            ],
+        });
+        for (let i = 0; i < 100; i++) {
+            logger.info('Testing ' + i);
+        }
+        await delay(0); // immediate delay causes logs to sync
+        await stream.end();
+    });
+
+    it('Sets up period correctly', async function () {
+        const stream = new RotatingFileStream({
+            period: '1w',
+            ...testConfig,
+        });
+        bunyan.createLogger({
+            name: 'foo',
+            streams: [
+                {
+                    stream,
+                },
+            ],
+        });
+        await stream.end();
+    });
+
+    it('Sets up long periods correctly', async function () {
+        const stream = new RotatingFileStream({
+            period: '1y',
+            ...testConfig,
+        });
+        bunyan.createLogger({
+            name: 'foo',
+            streams: [
+                {
+                    stream,
+                },
+            ],
+        });
+        await stream.end();
+    });
+
+    it('Goes fast with short periods', async function () {
+        const stream = new RotatingFileStream({
+            period: '50ms',
+            ...testConfig,
+        });
+        const logger = bunyan.createLogger({
+            name: 'foo',
+            streams: [
+                {
+                    stream,
+                },
+            ],
+        });
+        for (let i = 0; i < 10; i++) {
+            logger.info(`Testing ${i}!`);
+            await delay(50);
+        }
+        await stream.end();
+    });
+});

--- a/packages/bunyan-rotating-filestream/test/units.test.js
+++ b/packages/bunyan-rotating-filestream/test/units.test.js
@@ -1,0 +1,176 @@
+const assert = require('assert');
+const path = require('path');
+const zlib = require('zlib');
+const { promisify } = require('util');
+const fs = require('fs').promises;
+
+const FileRotator = require('../lib/fileRotator');
+const PeriodTrigger = require('../lib/periodTrigger');
+const ThresholdTrigger = require('../lib/thresholdTrigger');
+const WriteQueue = require('../lib/writeQueue');
+const { Rotate, NewFile, BytesWritten } = require('../lib/customEvents');
+
+const gunzip = promisify(zlib.gunzip);
+
+async function exists(filePath) {
+    try {
+        await fs.stat(filePath);
+        return true;
+    } catch (err) {
+        if (err.code === 'ENOENT') {
+            return false;
+        }
+        throw err;
+    }
+}
+
+describe('FileRotator', function () {
+    const logDir = 'logs/rotator';
+
+    beforeAll(async function () {
+        await fs.rm(logDir, { recursive: true, force: true });
+        await fs.mkdir(logDir, { recursive: true });
+    });
+
+    it('Rotates gzipped backups with %N naming and prunes to totalFiles', async function () {
+        const rotator = new FileRotator({
+            path: path.join(logDir, 'test_%N.log'),
+            totalFiles: 2,
+            gzip: true,
+            startNewFile: true,
+        });
+        const newFiles = [];
+        rotator.on(NewFile, (fileInfo) => newFiles.push(fileInfo));
+
+        await rotator.initialise();
+        // Initialising twice is a no-op
+        await rotator.initialise();
+
+        await rotator.getCurrentHandle().write('first\n');
+        await rotator.rotate();
+        await rotator.getCurrentHandle().write('second\n');
+        await rotator.rotate();
+        await rotator.getCurrentHandle().write('third\n');
+        await rotator.rotate();
+        await rotator.shutdown();
+
+        assert.ok(newFiles.length >= 4);
+        assert.strictEqual(await exists(path.join(logDir, 'test.log')), true);
+        assert.strictEqual(await exists(path.join(logDir, 'test_0.log.gz')), true);
+        assert.strictEqual(await exists(path.join(logDir, 'test_1.log.gz')), true);
+        assert.strictEqual(await exists(path.join(logDir, 'test_2.log.gz')), false);
+
+        const newestBackup = await gunzip(await fs.readFile(path.join(logDir, 'test_0.log.gz')));
+        assert.strictEqual(newestBackup.toString(), 'third\n');
+    });
+
+    it('Prunes backups over totalSize', async function () {
+        const rotator = new FileRotator({
+            path: path.join(logDir, 'size.log'),
+            totalSize: '1b',
+            startNewFile: true,
+        });
+
+        await rotator.initialise();
+        await rotator.getCurrentHandle().write('some data longer than one byte\n');
+        await rotator.rotate();
+        await rotator.getCurrentHandle().write('even more data longer than one byte\n');
+        await rotator.rotate();
+        await rotator.shutdown();
+
+        assert.strictEqual(await exists(path.join(logDir, 'size.log')), true);
+        assert.strictEqual(await exists(path.join(logDir, 'size.0.log')), true);
+        assert.strictEqual(await exists(path.join(logDir, 'size.1.log')), false);
+    });
+
+    it('Opens the existing file when startNewFile is not set', async function () {
+        const filePath = path.join(logDir, 'existing.log');
+        await fs.writeFile(filePath, 'already here\n');
+
+        const rotator = new FileRotator({
+            path: filePath,
+        });
+        await rotator.initialise();
+        await rotator.shutdown();
+
+        const contents = await fs.readFile(filePath, 'utf8');
+        assert.strictEqual(contents, 'already here\n');
+    });
+});
+
+describe('PeriodTrigger', function () {
+    const fileInfo = { birthtimeMs: Date.now() };
+
+    ['1h', '1d', '1w', '1m', '1y'].forEach(function (period) {
+        it(`Schedules the first rotation in the future for period "${period}"`, function () {
+            const trigger = new PeriodTrigger(period, false);
+            trigger.newFile(fileInfo);
+            assert.ok(trigger._rotateAt > Date.now());
+            trigger.shutdown();
+        });
+
+        it(`Schedules rotation from the existing file for period "${period}"`, function () {
+            const trigger = new PeriodTrigger(period, true);
+            trigger.newFile(fileInfo);
+            assert.ok(trigger._rotateAt > fileInfo.birthtimeMs);
+            trigger.shutdown();
+        });
+    });
+
+    it('Schedules millisecond periods from the existing file', function () {
+        const trigger = new PeriodTrigger('500ms', true);
+        trigger.newFile(fileInfo);
+        assert.strictEqual(trigger._rotateAt, fileInfo.birthtimeMs + 500);
+        trigger.shutdown();
+    });
+
+    it('Only rotates based on the existing file once', function () {
+        const trigger = new PeriodTrigger('1d', true);
+        trigger.newFile(fileInfo);
+        const firstRotateAt = trigger._rotateAt;
+        trigger.newFile({ birthtimeMs: 0 });
+        assert.ok(trigger._rotateAt >= firstRotateAt);
+        trigger.shutdown();
+    });
+
+    it('Shuts down cleanly before any file is seen', function () {
+        const trigger = new PeriodTrigger('1d', false);
+        trigger.shutdown();
+    });
+});
+
+describe('ThresholdTrigger', function () {
+    it('Emits a rotate event when the threshold is crossed', function () {
+        const trigger = new ThresholdTrigger('1k');
+        let rotations = 0;
+        trigger.on(Rotate, () => rotations++);
+
+        trigger.newFile({ size: 0 });
+        trigger.updateWritten(1000);
+        assert.strictEqual(rotations, 0);
+        trigger.updateWritten(1000);
+        assert.strictEqual(rotations, 1);
+        trigger.shutdown();
+    });
+});
+
+describe('WriteQueue', function () {
+    it('Shuts down cleanly when never given a file handle', async function () {
+        const queue = new WriteQueue();
+        queue.push('data\n');
+        await queue.shutdown();
+    });
+
+    it('Reports bytes written', async function () {
+        const queue = new WriteQueue();
+        const written = [];
+        queue.on(BytesWritten, (bytes) => written.push(bytes));
+        queue.setFileHandle({
+            write: async (data) => ({ bytesWritten: data.length }),
+        });
+        queue.push('data\n');
+        await queue.shutdown();
+        const totalWritten = written.reduce((total, bytes) => total + bytes, 0);
+        assert.strictEqual(totalWritten, 5);
+    });
+});

--- a/packages/bunyan-rotating-filestream/util/configProcessors.js
+++ b/packages/bunyan-rotating-filestream/util/configProcessors.js
@@ -1,0 +1,46 @@
+const processSize = (size) => {
+    const multipliers = {
+        b: 1,
+        k: 1024,
+        m: 1024 * 1024,
+        g: 1024 * 1024 * 1024,
+    };
+
+    if (typeof size === 'string') {
+        const [num, unit] = /^([1-9][0-9]*)([bkmg])$/.exec(size).slice(1);
+        return Number(num) * multipliers[unit];
+    } else {
+        return size;
+    }
+};
+
+const processPeriod = (period) => {
+    const result = {
+        num: 1,
+        unit: 'd',
+    };
+
+    // Parse `period`.
+    if (period) {
+        var crackedperiod =
+            {
+                hourly: '1h',
+                daily: '1d',
+                weekly: '1w',
+                monthly: '1m',
+                yearly: '1y',
+            }[period] || period;
+
+        const [num, unit] = /^([1-9][0-9]*)([hdwmy]|ms)$/.exec(crackedperiod).slice(1);
+
+        result.num = Number(num);
+        result.unit = unit;
+    }
+
+    return result;
+};
+
+module.exports = {
+    processSize,
+    processPeriod,
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -240,6 +240,19 @@ importers:
         specifier: 'catalog:'
         version: 22.0.0
 
+  packages/bunyan-rotating-filestream:
+    dependencies:
+      long-timeout:
+        specifier: 0.1.1
+        version: 0.1.1
+    devDependencies:
+      bunyan:
+        specifier: 1.8.15
+        version: 1.8.15
+      sinon:
+        specifier: 'catalog:'
+        version: 22.0.0
+
   packages/config:
     dependencies:
       '@tryghost/root-utils':
@@ -422,8 +435,8 @@ importers:
   packages/logging:
     dependencies:
       '@tryghost/bunyan-rotating-filestream':
-        specifier: 0.0.7
-        version: 0.0.7
+        specifier: workspace:*
+        version: link:../bunyan-rotating-filestream
       '@tryghost/elasticsearch':
         specifier: workspace:*
         version: link:../elasticsearch
@@ -2277,9 +2290,6 @@ packages:
 
   '@swc/helpers@0.5.23':
     resolution: {integrity: sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==}
-
-  '@tryghost/bunyan-rotating-filestream@0.0.7':
-    resolution: {integrity: sha512-dswM+dxG8J7WpVoSjzAdoWXqqB5Dg0C2T7Zh6eoUvl5hkA8yWWJi/fS4jNXlHF700lWQ0g8/t+leJ7SGSWd+aw==}
 
   '@tryghost/mongo-knex@0.10.1':
     resolution: {integrity: sha512-6LRA4zVpNvCrVrA9hOhs8N4iylAiafGssiKuD8yML/13xg2PvKw6dzOZj6hg0CKQwG7tVp8TA+7Nw3iDOzy/jQ==}
@@ -6838,10 +6848,6 @@ snapshots:
   '@swc/helpers@0.5.23':
     dependencies:
       tslib: 2.8.1
-
-  '@tryghost/bunyan-rotating-filestream@0.0.7':
-    dependencies:
-      long-timeout: 0.1.1
 
   '@tryghost/mongo-knex@0.10.1(supports-color@7.2.0)':
     dependencies:


### PR DESCRIPTION
## Why

The standalone `TryGhost/bunyan-rotating-filestream` repository was deleted, but `@tryghost/logging` still depends on the package. This recreates it inside the framework monorepo so it can be maintained and released alongside the other packages.

## What

- Recreated the package from the published npm tarball (v0.0.7) at `packages/bunyan-rotating-filestream`, source otherwise unchanged
- Adapted to monorepo conventions: Vitest with the shared coverage thresholds, oxlint/oxfmt, pnpm workspace, standard README/LICENSE/package.json layout
- Ported the mocha/should tests to Vitest and added unit tests for the rotation, pruning, and period-trigger logic (96.9% lines / 89.6% branches)
- Switched `@tryghost/logging` to consume the workspace version instead of the registry version

## Bug fixes

Two one-line fixes to the published source, both real bugs that Vitest surfaced as unhandled rejections (mocha silently tolerated them):

1. `lib/fileRotator.js` — `_gzipCurrentFile` called `fs.stat(inputName)` without `await`, making its ENOENT guard dead code, so a missing file crashed `createReadStream` instead of returning early
2. `index.js` — `end()` didn't wait for an in-flight rotation, so a rotation could keep running after the file handles were closed and collide with a new stream on the same path; `end()` now stops triggers first, then awaits the tracked rotation promise before draining

## Notes

- Version kept at 0.0.7 (matching npm); the next `ship` will bump it
- Full `pnpm test:ci`, root lint, and format check pass