### PR TITLE
Added flush helper for ensuring async loggers persist before shutdown

### DIFF
--- a/packages/elasticsearch/lib/ElasticSearchBunyan.js
+++ b/packages/elasticsearch/lib/ElasticSearchBunyan.js
@@ -9,13 +9,19 @@ class ElasticSearchBunyan {
         this.client = new ElasticSearch(clientConfig);
         this.index = index;
         this.pipeline = pipeline;
+        this.stream = null;
+        this.bulk = null;
     }
 
     getStream() {
         const index = this.index;
         const pipeline = this.pipeline;
         const stream = new PassThrough();
-        this.client.client.helpers.bulk({
+        // `helpers.bulk` batches documents and only ships them on a size/time
+        // threshold (30s flush interval by default) or when the source stream
+        // ends. It returns a thenable that resolves once the datasource is
+        // exhausted, which is what `flush()` awaits.
+        this.bulk = this.client.client.helpers.bulk({
             datasource: stream.pipe(split()),
             onDocument() {
                 return {
@@ -24,8 +30,35 @@ class ElasticSearchBunyan {
             },
             pipeline,
         });
+        this.stream = stream;
 
         return stream;
+    }
+
+    /**
+     * Force any buffered documents to ship, then wait for the in-flight bulk
+     * request to resolve. Ending the source stream flushes the bulk helper's
+     * buffer immediately instead of waiting for the flush interval, so callers
+     * can guarantee logs are shipped before the process exits.
+     *
+     * After a flush the stream is ended and can no longer be written to; this
+     * is intended as a shutdown step.
+     * @returns {Promise<void>}
+     */
+    async flush() {
+        if (!this.stream) {
+            return;
+        }
+
+        if (!this.stream.writableEnded) {
+            this.stream.end();
+        }
+
+        try {
+            await this.bulk;
+        } catch {
+            // Best-effort: never let a failed flush block shutdown.
+        }
     }
 }
 

--- a/packages/elasticsearch/test/ElasticSearch.test.js
+++ b/packages/elasticsearch/test/ElasticSearch.test.js
@@ -141,4 +141,80 @@ describe('ElasticSearch Bunyan', function () {
 
         assert.equal(bulkStub.callCount, 1);
     });
+
+    it('flush() ends the stream and awaits the bulk request', async function () {
+        const es = new ElasticSearchBunyan(
+            testClientConfig,
+            indexConfig.index,
+            indexConfig.pipeline,
+        );
+
+        let bulkResolved = false;
+        // Resolve the bulk promise only once the source stream has ended,
+        // mirroring how the real helper drains its buffer.
+        sandbox.stub(es.client.client.helpers, 'bulk').callsFake((data) => {
+            return (async () => {
+                // eslint-disable-next-line no-unused-vars
+                for await (const _chunk of data.datasource) {
+                    // drain the datasource
+                }
+                bulkResolved = true;
+            })();
+        });
+
+        const stream = es.getStream();
+        stream.write(JSON.stringify({ message: 'Test data' }));
+
+        await es.flush();
+
+        assert.equal(stream.writableEnded, true);
+        assert.equal(bulkResolved, true);
+    });
+
+    it('flush() can be called more than once without re-ending the stream', async function () {
+        const es = new ElasticSearchBunyan(
+            testClientConfig,
+            indexConfig.index,
+            indexConfig.pipeline,
+        );
+
+        sandbox.stub(es.client.client.helpers, 'bulk').resolves();
+
+        const stream = es.getStream();
+        const endSpy = sandbox.spy(stream, 'end');
+
+        await es.flush();
+        await es.flush();
+
+        assert.equal(stream.writableEnded, true);
+        assert.equal(endSpy.callCount, 1);
+    });
+
+    it('flush() is a no-op when no stream was created', async function () {
+        const es = new ElasticSearchBunyan(
+            testClientConfig,
+            indexConfig.index,
+            indexConfig.pipeline,
+        );
+
+        await assert.doesNotReject(async () => {
+            await es.flush();
+        });
+    });
+
+    it('flush() swallows a rejected bulk request', async function () {
+        const es = new ElasticSearchBunyan(
+            testClientConfig,
+            indexConfig.index,
+            indexConfig.pipeline,
+        );
+
+        sandbox.stub(es.client.client.helpers, 'bulk').returns(Promise.reject(new Error('boom')));
+
+        es.getStream();
+
+        await assert.doesNotReject(async () => {
+            await es.flush();
+        });
+    });
 });

--- a/packages/logging/lib/GhostLogger.d.ts
+++ b/packages/logging/lib/GhostLogger.d.ts
@@ -97,7 +97,7 @@ declare class GhostLogger {
     useLocalTime: boolean;
     metadata: Record<string, unknown>;
     rotation: RotationOptions;
-    streams: Record<string, { name: string; log: unknown }>;
+    streams: Record<string, { name: string; log: unknown; transport?: { flush(): Promise<void> } }>;
     serializers: Record<string, (input: any) => unknown>;
 
     constructor(options?: GhostLoggerOptions);
@@ -120,6 +120,13 @@ declare class GhostLogger {
     warn(...args: unknown[]): void;
     error(...args: unknown[]): void;
     fatal(...args: unknown[]): void;
+
+    /**
+     * Flush buffered logs on any transport that batches writes (e.g.
+     * ElasticSearch), forcing them out before the process exits. Resolves once
+     * every flushable transport has drained; failures are swallowed.
+     */
+    flush(): Promise<void>;
 
     /** Create a child logger with some properties bound to every log message. */
     child(boundProperties: Record<string, unknown>): GhostLogger;

--- a/packages/logging/lib/GhostLogger.js
+++ b/packages/logging/lib/GhostLogger.js
@@ -197,6 +197,9 @@ class GhostLogger {
 
         this.streams.elasticsearch = {
             name: 'elasticsearch',
+            // Keep a reference to the transport so `flush()` can force the
+            // buffered documents out before the process exits.
+            transport: elasticSearchInstance,
             log: bunyan.createLogger({
                 name: this.name,
                 streams: [
@@ -594,6 +597,38 @@ class GhostLogger {
 
     fatal() {
         this.log('fatal', toArray(arguments));
+    }
+
+    /**
+     * @description Flush buffered logs on any transport that batches writes.
+     *
+     * Asynchronous transports (e.g. ElasticSearch) buffer log lines and only
+     * ship them on a size/time threshold or when their stream ends. On a fatal
+     * boot error the process exits before that threshold is reached, so the
+     * crash reason is never shipped. Awaiting `flush()` before `process.exit()`
+     * forces those buffers out.
+     *
+     * Only transports exposing a `flush()` method are awaited; synchronous
+     * transports (stdout, stderr, file) have nothing to drain. Failures are
+     * swallowed so a broken transport can never block shutdown.
+     * @returns {Promise<void>}
+     */
+    async flush() {
+        const flushes = [];
+
+        each(this.streams, (stream) => {
+            if (stream.transport && typeof stream.transport.flush === 'function') {
+                // Defer the call into the promise chain so a synchronous throw
+                // is caught by the same `.catch()` as an async rejection.
+                flushes.push(
+                    Promise.resolve()
+                        .then(() => stream.transport.flush())
+                        .catch(() => {}),
+                );
+            }
+        });
+
+        await Promise.all(flushes);
     }
 
     /**

--- a/packages/logging/test/logging.test.js
+++ b/packages/logging/test/logging.test.js
@@ -296,6 +296,70 @@ describe('Logging', function () {
         );
     });
 
+    it('flush drains flushable transports', async function () {
+        const flushStub = sandbox.stub(ElasticSearch.prototype, 'flush').resolves();
+
+        const ghostLogger = new GhostLogger({
+            transports: ['stdout', 'elasticsearch'],
+            elasticsearch: {
+                index: 'ghost-index',
+                username: 'example',
+                password: 'password',
+                host: 'elastic-search-host',
+            },
+        });
+
+        await ghostLogger.flush();
+
+        assert.equal(flushStub.calledOnce, true);
+    });
+
+    it('flush resolves when no flushable transports are configured', async function () {
+        const ghostLogger = new GhostLogger({
+            transports: ['stdout'],
+        });
+
+        await assert.doesNotReject(async () => {
+            await ghostLogger.flush();
+        });
+    });
+
+    it('flush swallows an async rejection from a transport', async function () {
+        sandbox.stub(ElasticSearch.prototype, 'flush').rejects(new Error('boom'));
+
+        const ghostLogger = new GhostLogger({
+            transports: ['stdout', 'elasticsearch'],
+            elasticsearch: {
+                index: 'ghost-index',
+                username: 'example',
+                password: 'password',
+                host: 'elastic-search-host',
+            },
+        });
+
+        await assert.doesNotReject(async () => {
+            await ghostLogger.flush();
+        });
+    });
+
+    it('flush swallows a synchronous throw from a transport', async function () {
+        sandbox.stub(ElasticSearch.prototype, 'flush').throws(new Error('boom'));
+
+        const ghostLogger = new GhostLogger({
+            transports: ['stdout', 'elasticsearch'],
+            elasticsearch: {
+                index: 'ghost-index',
+                username: 'example',
+                password: 'password',
+                host: 'elastic-search-host',
+            },
+        });
+
+        await assert.doesNotReject(async () => {
+            await ghostLogger.flush();
+        });
+    });
+
     it('http writes a log message', async function () {
         await new Promise((resolve) => {
             sandbox.stub(HttpStream.prototype, 'write').callsFake(function (data) {


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PLA-254/fatal-boot-errors-are-lost-from-elasticsearch-no-logging-flush-before
- at present, if a `logging.error` call is made right before shutdown, the log push to Elasticsearch never happens and the error is swallowed
- add a `flush` method + wiring so that consumers can ensure logs are flushed before shutdown