### PR TITLE
Updated errors package to be isomorphic

### DIFF
--- a/packages/errors/src/GhostError.ts
+++ b/packages/errors/src/GhostError.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from 'crypto';
+import { randomUUID } from './random-uuid';
 import { wrapStack } from './wrap-stack';
 
 export interface GhostErrorOptions {

--- a/packages/errors/src/random-uuid.ts
+++ b/packages/errors/src/random-uuid.ts
@@ -1,0 +1,63 @@
+/**
+ * Isomorphic UUID v4 generator.
+ *
+ * Uses the global Web Crypto API rather than importing Node's `crypto` module,
+ * so this package can be bundled for the browser (e.g. Ghost's Ember admin)
+ * without pulling in Node built-ins.
+ *
+ * - Prefers `crypto.randomUUID()`, available in Node 19+ and in browsers, but
+ *   only in secure contexts (HTTPS/localhost).
+ * - Falls back to building a v4 UUID from `crypto.getRandomValues()`, which is
+ *   available even in insecure contexts.
+ */
+
+const globalCrypto: typeof globalThis.crypto | undefined = globalThis.crypto;
+
+const hex: string[] = [];
+for (let i = 0; i < 256; i += 1) {
+    hex.push((i + 0x100).toString(16).slice(1));
+}
+
+function uuidFromGetRandomValues(): string {
+    const bytes = new Uint8Array(16);
+    globalCrypto!.getRandomValues(bytes);
+
+    // Set the version (4) and variant (RFC 4122) bits.
+    bytes[6] = (bytes[6] & 0x0f) | 0x40;
+    bytes[8] = (bytes[8] & 0x3f) | 0x80;
+
+    return (
+        hex[bytes[0]] +
+        hex[bytes[1]] +
+        hex[bytes[2]] +
+        hex[bytes[3]] +
+        '-' +
+        hex[bytes[4]] +
+        hex[bytes[5]] +
+        '-' +
+        hex[bytes[6]] +
+        hex[bytes[7]] +
+        '-' +
+        hex[bytes[8]] +
+        hex[bytes[9]] +
+        '-' +
+        hex[bytes[10]] +
+        hex[bytes[11]] +
+        hex[bytes[12]] +
+        hex[bytes[13]] +
+        hex[bytes[14]] +
+        hex[bytes[15]]
+    );
+}
+
+export function randomUUID(): string {
+    if (globalCrypto?.randomUUID) {
+        return globalCrypto.randomUUID();
+    }
+
+    if (globalCrypto?.getRandomValues) {
+        return uuidFromGetRandomValues();
+    }
+
+    throw new Error('No secure random number generator available to generate a UUID');
+}

--- a/packages/errors/test/random-uuid.test.ts
+++ b/packages/errors/test/random-uuid.test.ts
@@ -1,0 +1,57 @@
+import assert from 'assert/strict';
+import { afterEach, describe, it, vi } from 'vitest';
+import { randomUUID } from '../src/random-uuid';
+
+const UUID_V4 = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+
+describe('randomUUID', function () {
+    afterEach(function () {
+        // Remove any own-property shadows added by a test, revealing the real
+        // Crypto.prototype methods again.
+        delete (globalThis.crypto as Record<string, unknown>).randomUUID;
+        delete (globalThis.crypto as Record<string, unknown>).getRandomValues;
+        vi.restoreAllMocks();
+    });
+
+    it('returns a valid v4 UUID', function () {
+        assert.match(randomUUID(), UUID_V4);
+    });
+
+    it('returns unique values', function () {
+        assert.notEqual(randomUUID(), randomUUID());
+    });
+
+    it('uses crypto.randomUUID when available', function () {
+        const spy = vi.spyOn(globalThis.crypto, 'randomUUID');
+        randomUUID();
+        assert.equal(spy.mock.calls.length, 1);
+    });
+
+    it('falls back to getRandomValues in insecure contexts', function () {
+        // Simulate an insecure browser context: randomUUID is unavailable,
+        // but getRandomValues still works.
+        Object.defineProperty(globalThis.crypto, 'randomUUID', {
+            value: undefined,
+            configurable: true,
+        });
+
+        const spy = vi.spyOn(globalThis.crypto, 'getRandomValues');
+        const id = randomUUID();
+
+        assert.ok(spy.mock.calls.length >= 1);
+        assert.match(id, UUID_V4);
+    });
+
+    it('throws when no random source is available', function () {
+        Object.defineProperty(globalThis.crypto, 'randomUUID', {
+            value: undefined,
+            configurable: true,
+        });
+        Object.defineProperty(globalThis.crypto, 'getRandomValues', {
+            value: undefined,
+            configurable: true,
+        });
+
+        assert.throws(() => randomUUID(), /No secure random number generator/);
+    });
+});


### PR DESCRIPTION
no ref
- errors was using `node:crypto` which isn't available in browsers, resulting in build errors in ghost-admin (imported via dep of @tryghost/limit-service)
- switch to isomorphic implementation via WebCrypto, falling back to getRandomValues in insecure contexts where randomUUID is not available