### PR TITLE
Reuse logging singleton across duplicate module copies via globalThis

### DIFF
--- a/packages/logging/README.md
+++ b/packages/logging/README.md
@@ -16,17 +16,20 @@ Ghost logging layer that configures logger instances, transports, and structured
 
 ## Shared singleton
 
-The package's default export is a single `GhostLogger` instance. To survive
-cases where the package fails to dedupe and more than one physical copy ends up
-in the `node_modules` tree, that instance is cached on `globalThis` and reused
-across every copy in the process. Without this, each copy would construct its
-own logger and each `RotatingFileStream` would open the same log file —
-multiple writers rotating one file corrupt it.
+The package's default export is a single `GhostLogger` instance per thread. To
+survive cases where the package fails to dedupe and more than one physical copy
+ends up in the `node_modules` tree, that instance is cached on `globalThis` and
+reused across every copy in the same thread. Without this, each copy would
+construct its own logger and each `RotatingFileStream` would open the same log
+file — multiple writers rotating one file corrupt it. Worker threads each have
+their own `globalThis`, so a worker builds its own instance (with the `parent`
+transport) rather than sharing the main thread's.
 
 The cache is keyed on the **major** version only (`Symbol.for('@tryghost/logging@<major>')`),
-so any `5.x` copies share one instance while an incompatible `6.x` gets its own.
-Whichever copy loads first constructs the instance; later copies of the same
-major reuse it as-is.
+so copies that share an installed major share one instance while copies on a
+different — and potentially incompatible — major each get their own. Whichever
+copy loads first constructs the instance; later copies of the same major reuse
+it as-is.
 
 ### ⚠️ Caution when adding methods
 

--- a/packages/logging/README.md
+++ b/packages/logging/README.md
@@ -14,6 +14,42 @@ Ghost logging layer that configures logger instances, transports, and structured
 
 ## Usage
 
+## Shared singleton
+
+The package's default export is a single `GhostLogger` instance. To survive
+cases where the package fails to dedupe and more than one physical copy ends up
+in the `node_modules` tree, that instance is cached on `globalThis` and reused
+across every copy in the process. Without this, each copy would construct its
+own logger and each `RotatingFileStream` would open the same log file —
+multiple writers rotating one file corrupt it.
+
+The cache is keyed on the **major** version only (`Symbol.for('@tryghost/logging@<major>')`),
+so any `5.x` copies share one instance while an incompatible `6.x` gets its own.
+Whichever copy loads first constructs the instance; later copies of the same
+major reuse it as-is.
+
+### ⚠️ Caution when adding methods
+
+Because a `5.2` consumer can end up sharing an instance that was constructed by
+a `5.1` copy that happened to load first, treat the instance's method surface as
+**append-only within a major, and never assume a method exists just because the
+current source has it**:
+
+- Adding a new method in a minor/patch is fine, but a caller running against an
+  older duplicate copy will hit `undefined` for it. New methods should be
+  additive and callers should tolerate their absence (`typeof logger.foo === 'function'`)
+  where a stale duplicate is plausible.
+- New methods must work over state produced by an _older_ constructor of the
+  same major. Do not rely on instance fields introduced in a newer constructor —
+  the shared instance may not have them. Prefer degrading gracefully (as
+  `flush()` does when a transport has no buffer) over throwing.
+- Renaming, removing, or changing the behaviour/signature of an existing method
+  is a breaking change and belongs in a **major** bump, which gets its own
+  cache slot.
+
+`resetForTesting()` clears the cached instance; it exists only so tests can force
+a fresh logger, since the cache otherwise survives `require`-cache resets.
+
 ## Develop
 
 This is a mono repository, managed with [Nx](https://nx.dev).

--- a/packages/logging/lib/logging.d.ts
+++ b/packages/logging/lib/logging.d.ts
@@ -6,6 +6,10 @@ import GhostLogger = require('./GhostLogger');
  */
 declare const logging: GhostLogger & {
     GhostLogger: typeof GhostLogger;
+    /**
+     * Clear the cached process-wide logger instance. Intended for tests only.
+     */
+    resetForTesting(): void;
 };
 
 declare namespace logging {

--- a/packages/logging/lib/logging.js
+++ b/packages/logging/lib/logging.js
@@ -2,17 +2,59 @@ const path = require('path');
 const { isMainThread } = require('worker_threads');
 const { getProcessRoot } = require('@tryghost/root-utils');
 const GhostLogger = require('./GhostLogger');
+const { version } = require('../package.json');
 
-let loggingConfig;
-try {
-    loggingConfig = require(path.join(getProcessRoot(), 'loggingrc'));
-} catch {
-    loggingConfig = {};
+/**
+ * Reuse a single logger instance across duplicate copies of this package that
+ * may co-exist in the node_modules tree.
+ *
+ * Node's module cache only guarantees one instance per *physical* copy of the
+ * package, so when the package fails to dedupe (incompatible ranges across
+ * consumers, peer-dep quirks) each copy constructs its own logger — and each
+ * RotatingFileStream then opens the *same* log path. Multiple rotating writers
+ * renaming/gzipping the same file corrupts rotation, so we must have exactly
+ * one instance per process (per thread).
+ *
+ * The instance is cached on `globalThis` under a key derived from the package
+ * MAJOR version. `Symbol.for` is used so the key resolves to the same symbol in
+ * every copy (the global symbol registry is shared process-wide); a plain
+ * `Symbol()` would be unique per copy and could never match.
+ *
+ * Gating on MAJOR only is deliberate: patch/minor duplicates (the common
+ * dedupe failure) share safely, but an incompatible major — which may have a
+ * different config shape or API — gets its own instance rather than silently
+ * reusing one built by a different major.
+ */
+const registryKey = Symbol.for(`@tryghost/logging@${parseInt(version, 10)}`);
+
+function createLogger() {
+    let loggingConfig;
+    try {
+        loggingConfig = require(path.join(getProcessRoot(), 'loggingrc'));
+    } catch {
+        loggingConfig = {};
+    }
+
+    if (!isMainThread) {
+        loggingConfig.transports = ['parent'];
+    }
+
+    return new GhostLogger(loggingConfig);
 }
 
-if (!isMainThread) {
-    loggingConfig.transports = ['parent'];
-}
-
-module.exports = new GhostLogger(loggingConfig);
+// worker_threads each get their own `globalThis`, so a worker still constructs
+// its own instance with the correct 'parent' transport — the main-thread logger
+// is never shared into a worker.
+module.exports = globalThis[registryKey] || (globalThis[registryKey] = createLogger());
 module.exports.GhostLogger = GhostLogger;
+
+/**
+ * @description Clear the cached process-wide logger instance.
+ *
+ * Only intended for tests: the instance is cached on `globalThis` and therefore
+ * survives `require`-cache resets within a process, so tests that need a fresh
+ * logger must clear it explicitly.
+ */
+module.exports.resetForTesting = function resetForTesting() {
+    delete globalThis[registryKey];
+};

--- a/packages/logging/test/logging.test.js
+++ b/packages/logging/test/logging.test.js
@@ -782,3 +782,66 @@ describe('Logging', function () {
         });
     });
 });
+
+describe('singleton reuse across module copies', function () {
+    const indexPath = require.resolve('../index');
+    const loggingPath = require.resolve('../lib/logging');
+    const { version } = require('../package.json');
+    const registryKey = Symbol.for(`@tryghost/logging@${parseInt(version, 10)}`);
+
+    // Force `lib/logging.js` to re-execute as if a second physical copy of the
+    // package were loading. Node's require cache would otherwise short-circuit
+    // it; clearing the cache re-runs the module and exercises the globalThis
+    // guard, which is the whole point of the singleton.
+    function loadAsFreshCopy() {
+        delete require.cache[indexPath];
+        delete require.cache[loggingPath];
+        return require('../index');
+    }
+
+    afterEach(function () {
+        // Leave a valid cached instance behind so the rest of the process sees
+        // the module's normal (already-required) state.
+        delete globalThis[registryKey];
+        loadAsFreshCopy();
+    });
+
+    it('caches the constructed instance on globalThis under a major-version key', function () {
+        delete globalThis[registryKey];
+
+        const logging = loadAsFreshCopy();
+
+        assert.equal(globalThis[registryKey], logging);
+    });
+
+    it('reuses the same instance when a duplicate copy re-executes the module', function () {
+        delete globalThis[registryKey];
+
+        const first = loadAsFreshCopy();
+        const second = loadAsFreshCopy();
+
+        assert.equal(second, first);
+    });
+
+    it('resetForTesting() clears the cache so the next load builds a new instance', function () {
+        const first = loadAsFreshCopy();
+
+        first.resetForTesting();
+        assert.equal(globalThis[registryKey], undefined);
+
+        const second = loadAsFreshCopy();
+        assert.notEqual(second, first);
+    });
+
+    it('gates the cache key on major version only', function () {
+        const major = parseInt(version, 10);
+
+        // Same major -> same key (patch/minor duplicates share).
+        assert.equal(registryKey, Symbol.for(`@tryghost/logging@${major}`));
+        // Different major -> different key (incompatible majors do not share).
+        assert.notEqual(
+            Symbol.for(`@tryghost/logging@${major}`),
+            Symbol.for(`@tryghost/logging@${major + 1}`),
+        );
+    });
+});


### PR DESCRIPTION
When @tryghost/logging fails to dedupe in the node_modules tree, each
physical copy runs its own `new GhostLogger()` and each RotatingFileStream
opens the same log path. Multiple rotating writers on one file corrupt
rotation (the bunyan-rotating-filestream failure).

Cache the instance on globalThis under a `Symbol.for` key derived from the
package major version. Symbol.for resolves to the same symbol across every
copy (shared global symbol registry), so duplicate copies converge on one
instance. Gating on major only means patch/minor duplicates share while an
incompatible major still gets its own instance. worker_threads keep their
own globalThis, so a worker still builds its own 'parent'-transport logger.

Adds resetForTesting() to clear the cache (the instance survives require-cache
resets) and tests covering reuse, reset, and major-version gating.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Cyj1FgH6XZiRPmedob7636