### PR TITLE
Made smart counting the default in bookshelf-pagination

### DIFF
--- a/packages/bookshelf-pagination/lib/bookshelf-pagination.js
+++ b/packages/bookshelf-pagination/lib/bookshelf-pagination.js
@@ -14,7 +14,7 @@ const messages = {
 let defaults;
 let paginationUtils;
 
-// Smart count only uses count(*) for single-table queries. Multi-table shapes
+// fetchPage only uses count(*) for single-table queries. Multi-table shapes
 // — outer JOINs, UNIONs, derived/raw FROM sources, or comma-separated FROM
 // lists — can duplicate base rows, so fetchPage must use count(distinct id).
 //
@@ -226,8 +226,9 @@ const pagination = function pagination(bookshelf) {
 
                 countQuery.clear('select');
                 // Skipping distinct for simple queries where we know result rows are unique.
-                const queryHasMultiTableSource = hasMultiTableSource(countQuery);
-                if (options.useBasicCount || (options.useSmartCount && !queryHasMultiTableSource)) {
+                // useBasicCount forces count(*) even for multi-table queries, for callers
+                // that know their result set is unique.
+                if (options.useBasicCount || !hasMultiTableSource(countQuery)) {
                     countPromise = countQuery.select(bookshelf.knex.raw('count(*) as aggregate'));
                 } else {
                     countPromise = countQuery.select(

--- a/packages/bookshelf-pagination/test/pagination-integration.test.js
+++ b/packages/bookshelf-pagination/test/pagination-integration.test.js
@@ -167,11 +167,11 @@ function usesCountDistinct(sql) {
 }
 
 describe('fetchPage end-to-end against real bookshelf + sqlite', function () {
-    // These two tests are the only fetchPage scenarios where the choice of
-    // count aggregate actually changes the returned total (inner-join row
-    // duplication) or is the named regression the PR is about (subquery
-    // JOIN in WHERE). The remaining query shapes are covered by the direct
-    // `hasMultiTableSource` suite above, which is faster and more exhaustive.
+    // These tests cover the fetchPage scenarios where the choice of count
+    // aggregate actually changes the returned total (inner-join row
+    // duplication) or was a named regression (subquery JOIN in WHERE). The
+    // remaining query shapes are covered by the direct `hasMultiTableSource`
+    // suite above, which is faster and more exhaustive.
     let db;
     let Post;
     let queries;
@@ -197,7 +197,7 @@ describe('fetchPage end-to-end against real bookshelf + sqlite', function () {
                     'published',
                 );
             })
-            .fetchPage({ page: 1, limit: 10, useSmartCount: true });
+            .fetchPage({ page: 1, limit: 10 });
 
         const countSql = countQuerySql(queries);
         assert.ok(usesCountDistinct(countSql), `expected count(distinct), got: ${countSql}`);
@@ -215,7 +215,7 @@ describe('fetchPage end-to-end against real bookshelf + sqlite', function () {
                         .where('authors.name', 'Alice');
                 });
             })
-            .fetchPage({ page: 1, limit: 10, useSmartCount: true });
+            .fetchPage({ page: 1, limit: 10 });
 
         const countSql = countQuerySql(queries);
         assert.ok(usesCountStar(countSql), `expected count(*), got: ${countSql}`);


### PR DESCRIPTION
The `smarterCounts` labs flag is becoming the default in Ghost, so this removes the `useSmartCount` opt-in from the pagination plugin and makes it the default behaviour:

- `fetchPage` now uses `count(*)` whenever the query has a single-table source, falling back to `count(distinct id)` for multi-table shapes (joins, unions, derived/raw FROM sources)
- `useBasicCount` remains as an explicit override forcing `count(*)` for callers that know their multi-table result set is unique
- Ghost core passing `useSmartCount: true` behind the labs flag becomes a harmless no-op, so this can ship in either order; once released and bumped in Ghost, the labs conditional and flag registration there can be removed