### PR TITLE
Updated dependency `got` to v15.1.0

### DIFF
--- a/packages/request/package.json
+++ b/packages/request/package.json
@@ -27,7 +27,7 @@
     "@tryghost/validator": "workspace:*",
     "@tryghost/version": "workspace:*",
     "cacheable-lookup": "7.0.0",
-    "got": "14.6.6",
+    "got": "15.1.0",
     "lodash": "4.18.1"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -649,8 +649,8 @@ importers:
         specifier: 7.0.0
         version: 7.0.0
       got:
-        specifier: 14.6.6
-        version: 14.6.6
+        specifier: 15.1.0
+        version: 15.1.0
       lodash:
         specifier: 4.18.1
         version: 4.18.1
@@ -2232,6 +2232,10 @@ packages:
     resolution: {integrity: sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==}
     engines: {node: '>=18'}
 
+  '@sindresorhus/is@8.1.0':
+    resolution: {integrity: sha512-2SX/1jW6CIMAiebvVv5ZInoCEuWQmMyBoJXXGC6Vjakjp/fpxP5eHs7/V6WKuPEIbuK06+VpjH+vjLQhr98rDQ==}
+    engines: {node: '>=22'}
+
   '@sinonjs/commons@3.0.1':
     resolution: {integrity: sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==}
 
@@ -2887,6 +2891,10 @@ packages:
   chownr@3.0.0:
     resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
     engines: {node: '>=18'}
+
+  chunk-data@0.1.0:
+    resolution: {integrity: sha512-zFyPtyC0SZ6Zu79b9sOYtXZcgrsXe0RpePrzRyj52hYVFG1+Rk6rBqjjOEk+GNQwc3PIX+86teQMok970pod1g==}
+    engines: {node: '>=20'}
 
   ci-info@4.4.0:
     resolution: {integrity: sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==}
@@ -3651,6 +3659,10 @@ packages:
     resolution: {integrity: sha512-QLV1qeYSo5l13mQzWgP/y0LbMr5Plr5fJilgAIwgnwseproEbtNym8xpLsDzeZ6MWXgNE6kdWGBjdh3zT/Qerg==}
     engines: {node: '>=20'}
 
+  got@15.1.0:
+    resolution: {integrity: sha512-DG+DAAkRtno+oDr/GBsliAkhN9+zczOPM5qXk3efDZY3qvyRnZU+NwQlb/IOY6cSnxxTR9z3aHCcShJyjb0hJA==}
+    engines: {node: '>=22'}
+
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
@@ -4108,6 +4120,10 @@ packages:
   lowercase-keys@3.0.0:
     resolution: {integrity: sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  lowercase-keys@4.0.1:
+    resolution: {integrity: sha512-wI9Nui/L8VfADa/cr/7NQruaASk1k23/Uh1khQ02BCVYiiy8F4AhOGnQzJy3Fl/c44GnYSbZHv8g7EcG3kJ1Qg==}
+    engines: {node: '>=20'}
 
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
@@ -4886,6 +4902,10 @@ packages:
     resolution: {integrity: sha512-LDt2stNTp4bVPMgd70Jj9PWrSa4batl+bv+Ea5NLNGT7ufc4oQPtRfQ73wbddNV6RilaPqnEt6y1Wkm5FVTNEg==}
     engines: {node: '>=4'}
 
+  tagged-tag@1.0.0:
+    resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
+    engines: {node: '>=20'}
+
   tar-fs@2.1.5:
     resolution: {integrity: sha512-OboTd8mmMhZDNPV+UjQcK9yKAatXu2aJ+r1w4im1Otd4M4fl2hwvdoXUxIYHFTHWK/3y3FarBP70v3vwmGlOxw==}
 
@@ -4987,6 +5007,10 @@ packages:
     resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
     engines: {node: '>=16'}
 
+  type-fest@5.8.0:
+    resolution: {integrity: sha512-YGYEVz3Fm5iy/AybuA0oyNFq7H4CgQNfRp/qfe8nurE1kuCeNm3/vfm9X4Mtl+qLyaKJUh5xrFZwogr41SMjYA==}
+    engines: {node: '>=20'}
+
   type-is@1.6.18:
     resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
     engines: {node: '>= 0.6'}
@@ -5006,6 +5030,10 @@ packages:
   uid-safe@2.1.5:
     resolution: {integrity: sha512-KPHm4VL5dDXKz01UuEd88Df+KzynaohSL9fBh096KWAxSKZQDI2uBrVqtvRM4rwrIrRRKsdLNML/lnaaVSRioA==}
     engines: {node: '>= 0.8'}
+
+  uint8array-extras@1.5.0:
+    resolution: {integrity: sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==}
+    engines: {node: '>=18'}
 
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
@@ -6824,6 +6852,8 @@ snapshots:
 
   '@sindresorhus/is@7.2.0': {}
 
+  '@sindresorhus/is@8.1.0': {}
+
   '@sinonjs/commons@3.0.1':
     dependencies:
       type-detect: 4.0.8
@@ -7520,6 +7550,8 @@ snapshots:
 
   chownr@3.0.0: {}
 
+  chunk-data@0.1.0: {}
+
   ci-info@4.4.0: {}
 
   cli-cursor@3.1.0:
@@ -8174,6 +8206,21 @@ snapshots:
       responselike: 4.0.2
       type-fest: 4.41.0
 
+  got@15.1.0:
+    dependencies:
+      '@sindresorhus/is': 8.1.0
+      byte-counter: 0.1.0
+      cacheable-lookup: 7.0.0
+      cacheable-request: 13.0.19
+      chunk-data: 0.1.0
+      decompress-response: 10.0.0
+      http2-wrapper: 2.2.1
+      keyv: 5.6.0
+      lowercase-keys: 4.0.1
+      responselike: 4.0.2
+      type-fest: 5.8.0
+      uint8array-extras: 1.5.0
+
   graceful-fs@4.2.11: {}
 
   has-flag@4.0.0: {}
@@ -8604,6 +8651,8 @@ snapshots:
   long-timeout@0.1.1: {}
 
   lowercase-keys@3.0.0: {}
+
+  lowercase-keys@4.0.1: {}
 
   lru-cache@5.1.1:
     dependencies:
@@ -9596,6 +9645,8 @@ snapshots:
 
   sywac@1.3.0: {}
 
+  tagged-tag@1.0.0: {}
+
   tar-fs@2.1.5:
     dependencies:
       chownr: 1.1.4
@@ -9704,6 +9755,10 @@ snapshots:
 
   type-fest@4.41.0: {}
 
+  type-fest@5.8.0:
+    dependencies:
+      tagged-tag: 1.0.0
+
   type-is@1.6.18:
     dependencies:
       media-typer: 0.3.0
@@ -9743,6 +9798,8 @@ snapshots:
   uid-safe@2.1.5:
     dependencies:
       random-bytes: 1.0.0
+
+  uint8array-extras@1.5.0: {}
 
   undici-types@7.18.2: {}
 


### PR DESCRIPTION
## Why

got ≤14.6.6 has an unguarded `this._request.destroyed` check in the write callback of `_writeRequest`. When a redirect clears `_request` while a body write callback is still outstanding, that dereference throws a `TypeError` as an `uncaughtException` and takes the Ghost process down — see https://github.com/TryGhost/Ghost/issues/30001. The fix (capturing `request` and checking `this._request === request`) only landed in got 15.0.0 (https://github.com/sindresorhus/got/releases/tag/v15.0.0). Ghost core will be unified onto the same got version afterwards, so `@tryghost/request` needs to lead.

## What changed

- `packages/request/package.json`: `got` `14.6.6` → `15.1.0` (latest 15.x; 15.0.1–15.1.0 are bug fixes plus the additive `allowAbsoluteUrls` option)
- `pnpm-lock.yaml`: got 15.1.0 and its new transitive deps (`@sindresorhus/is@8`, `type-fest@5`, `lowercase-keys@4`, `chunk-data`, `uint8array-extras`, `tagged-tag`)

## Code adaptations

None required. `lib/request.js` was audited against every v15 breaking change:

| v15 breaking change | Impact on `lib/request.js` |
| --- | --- |
| Node ≥22 required | Repo already targets Node 22/24 (CI matrix, `.nvmrc` 24) |
| `promise.cancel()` removed | Not used; `request()` is `async` and never exposed got's promise |
| `isStream` option removed | Not used |
| Native `FormData` | Not used |
| `responseType: 'buffer'` → `Uint8Array` | Not used |
| `strictContentLength` default `true` | Not set; passed through from callers |
| `retry.enforceRetryRules` default `true` | Only `retry.limit` is set (in test env) |
| Piped header copying opt-in | Not used |
| `url` removed from hook options | Package has no hooks. `Object.assign(error, error.options)` already copied nothing useful in v14 (only `_internals`/`_merging`/`_init`/`_unixOptions` own props); in v15 `Options` has no own enumerable props so it copies nothing. `err.url`/`err.method` on thrown errors continue to come from `error.response`, as before |
| 300/304 no longer auto-followed | Not handled here; passthrough |
| Named export removed | Already uses `(await import('got')).default` |

## Test results

```
cd packages/request && corepack pnpm test
 Test Files  2 passed (2)
      Tests  20 passed (20)
Coverage: 100% stmts / 95.45% branches / 100% funcs / 100% lines
$ pnpm run lint  (oxlint)  ✓
```

Root: `corepack pnpm lint` ✓, `corepack pnpm format:check` ✓ (Node 22.23.1 locally; CI covers 22 + 24).

## Consumer-facing changes

`@tryghost/request` passes options straight through to got, so callers inherit got 15's behaviour:

- **Node ≥22** is now required transitively (got 15 `engines.node: >=22`). This package has never declared its own `engines` field and the repo already only supports Node 22/24, so no `engines` change was made — but this is a hard runtime floor for consumers on Node 20 and older.
- **`strictContentLength` defaults to `true`**: a `Content-Length` header that does not match the actual body size now throws `ContentLengthMismatchError` instead of being sent. Pass `{strictContentLength: false}` to restore.
- **`retry.enforceRetryRules` defaults to `true`**: custom `calculateDelay` is only consulted when `limit`/`methods`/`statusCodes`/`errorCodes` allow a retry.
- **`responseType: 'buffer'`** now returns `Uint8Array` (a `Buffer` superclass); code doing `Buffer.isBuffer(res.body)` or relying on Buffer-only methods needs adjusting. Ghost core uses this in `themes/installer.js`, `lib/image/image-utils.js`, `oembed-service.js`.
- **300 and 304 responses are no longer auto-followed** as redirects.
- **`isStream: true`** and **`promise.cancel()`** are gone (use `got.stream()` / `signal`). Neither was reachable via this package's API in practice.
- Errors thrown from `request()` no longer carry got's private `_internals`/`_merging`/`_init`/`_unixOptions` fields (v14 leaked them via `Object.assign(error, error.options)`); public fields (`code`, `response`, `statusCode`, `body`, `url`, `method`, ...) are unchanged.

## Release note

This repo versions at ship time via `pnpm ship:*` (no changesets). Given the transitive Node ≥22 floor and the got behaviour changes above, this should ship as at least a **minor** (`3.4.0`); a **major** is defensible if we treat the Node floor as a package contract change.
