### PR TITLE
Allowed filtered releases to skip dependents

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -41,6 +41,7 @@
     "projects": ["packages/*"],
     "projectsRelationship": "independent",
     "version": {
+      "updateDependents": "never",
       "preserveMatchingDependencyRanges": false,
       "git": {
         "commit": true,


### PR DESCRIPTION
## Why

The `got` 15 upgrade in #911 needs to ship `@tryghost/request` as a standalone major release. With the current Nx configuration, filtering the release to `@tryghost/request` still schedules patch releases for its transitive framework dependents because Nx defaults `updateDependents` to `always`.

## What changed

Set `release.version.updateDependents` to `never` so an explicitly filtered release only versions the selected project. Unfiltered `ship:*` commands still select and version all framework packages as before.

## Validation

```text
$ corepack pnpm nx release version major --projects=@tryghost/request --dry-run
@tryghost/request 3.3.7 -> 4.0.0
```

The dry run updates only `packages/request/package.json`; no dependent package releases are scheduled.

- `corepack pnpm format:check` ✓
- `git diff --check` ✓