### PR TITLE
🎨 Updated workspace package refs to ^ selector

### DIFF
--- a/packages/api-framework/package.json
+++ b/packages/api-framework/package.json
@@ -21,11 +21,11 @@
     "lint": "oxlint -c ../../.oxlintrc.json ."
   },
   "dependencies": {
-    "@tryghost/debug": "workspace:*",
-    "@tryghost/errors": "workspace:*",
-    "@tryghost/promise": "workspace:*",
-    "@tryghost/tpl": "workspace:*",
-    "@tryghost/validator": "workspace:*",
+    "@tryghost/debug": "workspace:^",
+    "@tryghost/errors": "workspace:^",
+    "@tryghost/promise": "workspace:^",
+    "@tryghost/tpl": "workspace:^",
+    "@tryghost/validator": "workspace:^",
     "lodash": "4.18.1"
   },
   "devDependencies": {

--- a/packages/bookshelf-collision/package.json
+++ b/packages/bookshelf-collision/package.json
@@ -23,7 +23,7 @@
     "posttest": "pnpm run lint"
   },
   "dependencies": {
-    "@tryghost/errors": "workspace:*",
+    "@tryghost/errors": "workspace:^",
     "lodash": "4.18.1",
     "moment-timezone": "^0.5.33"
   },

--- a/packages/bookshelf-eager-load/package.json
+++ b/packages/bookshelf-eager-load/package.json
@@ -23,7 +23,7 @@
     "posttest": "pnpm run lint"
   },
   "dependencies": {
-    "@tryghost/debug": "workspace:*",
+    "@tryghost/debug": "workspace:^",
     "lodash": "4.18.1"
   },
   "devDependencies": {

--- a/packages/bookshelf-filter/package.json
+++ b/packages/bookshelf-filter/package.json
@@ -23,10 +23,10 @@
     "posttest": "pnpm run lint"
   },
   "dependencies": {
-    "@tryghost/debug": "workspace:*",
-    "@tryghost/errors": "workspace:*",
+    "@tryghost/debug": "workspace:^",
+    "@tryghost/errors": "workspace:^",
     "@tryghost/nql": "0.13.2",
-    "@tryghost/tpl": "workspace:*"
+    "@tryghost/tpl": "workspace:^"
   },
   "devDependencies": {
     "sinon": "catalog:"

--- a/packages/bookshelf-has-posts/package.json
+++ b/packages/bookshelf-has-posts/package.json
@@ -23,7 +23,7 @@
     "posttest": "pnpm run lint"
   },
   "dependencies": {
-    "@tryghost/debug": "workspace:*",
+    "@tryghost/debug": "workspace:^",
     "lodash": "4.18.1"
   },
   "devDependencies": {

--- a/packages/bookshelf-include-count/package.json
+++ b/packages/bookshelf-include-count/package.json
@@ -23,7 +23,7 @@
     "posttest": "pnpm run lint"
   },
   "dependencies": {
-    "@tryghost/debug": "workspace:*",
+    "@tryghost/debug": "workspace:^",
     "lodash": "4.18.1"
   },
   "devDependencies": {

--- a/packages/bookshelf-pagination/package.json
+++ b/packages/bookshelf-pagination/package.json
@@ -23,8 +23,8 @@
     "posttest": "pnpm run lint"
   },
   "dependencies": {
-    "@tryghost/errors": "workspace:*",
-    "@tryghost/tpl": "workspace:*",
+    "@tryghost/errors": "workspace:^",
+    "@tryghost/tpl": "workspace:^",
     "lodash": "4.18.1"
   },
   "devDependencies": {

--- a/packages/bookshelf-plugins/package.json
+++ b/packages/bookshelf-plugins/package.json
@@ -23,16 +23,16 @@
     "posttest": "pnpm run lint"
   },
   "dependencies": {
-    "@tryghost/bookshelf-collision": "workspace:*",
-    "@tryghost/bookshelf-custom-query": "workspace:*",
-    "@tryghost/bookshelf-eager-load": "workspace:*",
-    "@tryghost/bookshelf-filter": "workspace:*",
-    "@tryghost/bookshelf-has-posts": "workspace:*",
-    "@tryghost/bookshelf-include-count": "workspace:*",
-    "@tryghost/bookshelf-order": "workspace:*",
-    "@tryghost/bookshelf-pagination": "workspace:*",
-    "@tryghost/bookshelf-search": "workspace:*",
-    "@tryghost/bookshelf-transaction-events": "workspace:*"
+    "@tryghost/bookshelf-collision": "workspace:^",
+    "@tryghost/bookshelf-custom-query": "workspace:^",
+    "@tryghost/bookshelf-eager-load": "workspace:^",
+    "@tryghost/bookshelf-filter": "workspace:^",
+    "@tryghost/bookshelf-has-posts": "workspace:^",
+    "@tryghost/bookshelf-include-count": "workspace:^",
+    "@tryghost/bookshelf-order": "workspace:^",
+    "@tryghost/bookshelf-pagination": "workspace:^",
+    "@tryghost/bookshelf-search": "workspace:^",
+    "@tryghost/bookshelf-transaction-events": "workspace:^"
   },
   "devDependencies": {
     "sinon": "catalog:"

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -23,7 +23,7 @@
     "posttest": "pnpm run lint"
   },
   "dependencies": {
-    "@tryghost/root-utils": "workspace:*",
+    "@tryghost/root-utils": "workspace:^",
     "nconf": "0.13.0"
   }
 }

--- a/packages/debug/package.json
+++ b/packages/debug/package.json
@@ -25,7 +25,7 @@
     "posttest": "pnpm run lint"
   },
   "dependencies": {
-    "@tryghost/root-utils": "workspace:*",
+    "@tryghost/root-utils": "workspace:^",
     "debug": "4.4.3"
   }
 }

--- a/packages/domain-events/package.json
+++ b/packages/domain-events/package.json
@@ -23,6 +23,6 @@
     "lint": "oxlint -c ../../.oxlintrc.json ."
   },
   "dependencies": {
-    "@tryghost/logging": "workspace:*"
+    "@tryghost/logging": "workspace:^"
   }
 }

--- a/packages/elasticsearch/package.json
+++ b/packages/elasticsearch/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "@elastic/elasticsearch": "8.19.2",
-    "@tryghost/debug": "workspace:*",
+    "@tryghost/debug": "workspace:^",
     "split2": "4.2.0"
   },
   "devDependencies": {

--- a/packages/express-test/package.json
+++ b/packages/express-test/package.json
@@ -23,7 +23,7 @@
     "posttest": "pnpm run lint"
   },
   "dependencies": {
-    "@tryghost/jest-snapshot": "workspace:*",
+    "@tryghost/jest-snapshot": "workspace:^",
     "cookiejar": "2.1.4",
     "form-data": "4.0.6",
     "mime-types": "3.0.2"

--- a/packages/http-stream/package.json
+++ b/packages/http-stream/package.json
@@ -23,8 +23,8 @@
     "posttest": "pnpm run lint"
   },
   "dependencies": {
-    "@tryghost/errors": "workspace:*",
-    "@tryghost/request": "workspace:*"
+    "@tryghost/errors": "workspace:^",
+    "@tryghost/request": "workspace:^"
   },
   "devDependencies": {
     "express": "5.2.1",

--- a/packages/jest-snapshot/package.json
+++ b/packages/jest-snapshot/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "@jest/expect": "30.4.1",
     "@jest/expect-utils": "30.4.1",
-    "@tryghost/errors": "workspace:*",
+    "@tryghost/errors": "workspace:^",
     "jest-snapshot": "30.4.1"
   },
   "devDependencies": {

--- a/packages/job-manager/package.json
+++ b/packages/job-manager/package.json
@@ -23,8 +23,8 @@
   },
   "dependencies": {
     "@breejs/later": "4.2.0",
-    "@tryghost/errors": "workspace:*",
-    "@tryghost/logging": "workspace:*",
+    "@tryghost/errors": "workspace:^",
+    "@tryghost/logging": "workspace:^",
     "bree": "9.2.9",
     "cron-validate": "1.5.3",
     "fastq": "1.20.1",

--- a/packages/logging/package.json
+++ b/packages/logging/package.json
@@ -25,11 +25,11 @@
     "posttest": "pnpm run lint"
   },
   "dependencies": {
-    "@tryghost/bunyan-rotating-filestream": "workspace:*",
-    "@tryghost/elasticsearch": "workspace:*",
-    "@tryghost/http-stream": "workspace:*",
-    "@tryghost/pretty-stream": "workspace:*",
-    "@tryghost/root-utils": "workspace:*",
+    "@tryghost/bunyan-rotating-filestream": "workspace:^",
+    "@tryghost/elasticsearch": "workspace:^",
+    "@tryghost/http-stream": "workspace:^",
+    "@tryghost/pretty-stream": "workspace:^",
+    "@tryghost/root-utils": "workspace:^",
     "bunyan": "1.8.15",
     "fs-extra": "11.4.0",
     "gelf-stream": "1.1.1",
@@ -37,7 +37,7 @@
     "lodash": "4.18.1"
   },
   "devDependencies": {
-    "@tryghost/errors": "workspace:*",
+    "@tryghost/errors": "workspace:^",
     "sinon": "catalog:"
   }
 }

--- a/packages/metrics/package.json
+++ b/packages/metrics/package.json
@@ -25,9 +25,9 @@
     "posttest": "pnpm run lint"
   },
   "dependencies": {
-    "@tryghost/elasticsearch": "workspace:*",
-    "@tryghost/pretty-stream": "workspace:*",
-    "@tryghost/root-utils": "workspace:*",
+    "@tryghost/elasticsearch": "workspace:^",
+    "@tryghost/pretty-stream": "workspace:^",
+    "@tryghost/root-utils": "workspace:^",
     "json-stringify-safe": "5.0.1"
   },
   "devDependencies": {

--- a/packages/mw-error-handler/package.json
+++ b/packages/mw-error-handler/package.json
@@ -23,10 +23,10 @@
     "lint": "oxlint -c ../../.oxlintrc.json ."
   },
   "dependencies": {
-    "@tryghost/debug": "workspace:*",
-    "@tryghost/errors": "workspace:*",
-    "@tryghost/http-cache-utils": "workspace:*",
-    "@tryghost/tpl": "workspace:*",
+    "@tryghost/debug": "workspace:^",
+    "@tryghost/errors": "workspace:^",
+    "@tryghost/http-cache-utils": "workspace:^",
+    "@tryghost/tpl": "workspace:^",
     "lodash": "4.18.1",
     "semver": "7.8.5"
   },

--- a/packages/nodemailer/package.json
+++ b/packages/nodemailer/package.json
@@ -24,8 +24,8 @@
   },
   "dependencies": {
     "@aws-sdk/client-sesv2": "3.1110.0",
-    "@tryghost/errors": "workspace:*",
-    "@tryghost/tpl": "workspace:*",
+    "@tryghost/errors": "workspace:^",
+    "@tryghost/tpl": "workspace:^",
     "nodemailer": "9.0.5",
     "nodemailer-mailgun-transport": "2.1.5",
     "nodemailer-stub-transport": "1.1.0"

--- a/packages/prometheus-metrics/package.json
+++ b/packages/prometheus-metrics/package.json
@@ -26,8 +26,8 @@
     "lint": "oxlint -c ../../.oxlintrc.json ."
   },
   "dependencies": {
-    "@tryghost/debug": "workspace:*",
-    "@tryghost/logging": "workspace:*",
+    "@tryghost/debug": "workspace:^",
+    "@tryghost/logging": "workspace:^",
     "express": "5.2.1",
     "prom-client": "15.1.3",
     "stoppable": "1.1.0"

--- a/packages/request/package.json
+++ b/packages/request/package.json
@@ -23,9 +23,9 @@
     "posttest": "pnpm run lint"
   },
   "dependencies": {
-    "@tryghost/errors": "workspace:*",
-    "@tryghost/validator": "workspace:*",
-    "@tryghost/version": "workspace:*",
+    "@tryghost/errors": "workspace:^",
+    "@tryghost/validator": "workspace:^",
+    "@tryghost/version": "workspace:^",
     "cacheable-lookup": "7.0.0",
     "got": "15.1.0",
     "lodash": "4.18.1"

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -23,8 +23,8 @@
     "posttest": "pnpm run lint"
   },
   "dependencies": {
-    "@tryghost/debug": "workspace:*",
-    "@tryghost/logging": "workspace:*"
+    "@tryghost/debug": "workspace:^",
+    "@tryghost/logging": "workspace:^"
   },
   "devDependencies": {
     "sinon": "catalog:"

--- a/packages/validator/package.json
+++ b/packages/validator/package.json
@@ -23,8 +23,8 @@
     "posttest": "pnpm run lint"
   },
   "dependencies": {
-    "@tryghost/errors": "workspace:*",
-    "@tryghost/tpl": "workspace:*",
+    "@tryghost/errors": "workspace:^",
+    "@tryghost/tpl": "workspace:^",
     "lodash": "4.18.1",
     "moment-timezone": "^0.5.23",
     "validator": "13.15.35"

--- a/packages/version/package.json
+++ b/packages/version/package.json
@@ -23,7 +23,7 @@
     "posttest": "pnpm run lint"
   },
   "dependencies": {
-    "@tryghost/root-utils": "workspace:*",
+    "@tryghost/root-utils": "workspace:^",
     "semver": "7.8.5"
   },
   "devDependencies": {

--- a/packages/zip/package.json
+++ b/packages/zip/package.json
@@ -23,7 +23,7 @@
     "posttest": "pnpm run lint"
   },
   "dependencies": {
-    "@tryghost/errors": "workspace:*",
+    "@tryghost/errors": "workspace:^",
     "archiver": "8.0.0",
     "extract-zip": "2.0.1"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,19 +54,19 @@ importers:
   packages/api-framework:
     dependencies:
       '@tryghost/debug':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../debug
       '@tryghost/errors':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../errors
       '@tryghost/promise':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../promise
       '@tryghost/tpl':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../tpl
       '@tryghost/validator':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../validator
       lodash:
         specifier: 4.18.1
@@ -79,7 +79,7 @@ importers:
   packages/bookshelf-collision:
     dependencies:
       '@tryghost/errors':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../errors
       lodash:
         specifier: 4.18.1
@@ -101,7 +101,7 @@ importers:
   packages/bookshelf-eager-load:
     dependencies:
       '@tryghost/debug':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../debug
       lodash:
         specifier: 4.18.1
@@ -114,16 +114,16 @@ importers:
   packages/bookshelf-filter:
     dependencies:
       '@tryghost/debug':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../debug
       '@tryghost/errors':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../errors
       '@tryghost/nql':
         specifier: 0.13.2
         version: 0.13.2(supports-color@8.1.1)
       '@tryghost/tpl':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../tpl
     devDependencies:
       sinon:
@@ -133,7 +133,7 @@ importers:
   packages/bookshelf-has-posts:
     dependencies:
       '@tryghost/debug':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../debug
       lodash:
         specifier: 4.18.1
@@ -146,7 +146,7 @@ importers:
   packages/bookshelf-include-count:
     dependencies:
       '@tryghost/debug':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../debug
       lodash:
         specifier: 4.18.1
@@ -169,10 +169,10 @@ importers:
   packages/bookshelf-pagination:
     dependencies:
       '@tryghost/errors':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../errors
       '@tryghost/tpl':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../tpl
       lodash:
         specifier: 4.18.1
@@ -194,34 +194,34 @@ importers:
   packages/bookshelf-plugins:
     dependencies:
       '@tryghost/bookshelf-collision':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../bookshelf-collision
       '@tryghost/bookshelf-custom-query':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../bookshelf-custom-query
       '@tryghost/bookshelf-eager-load':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../bookshelf-eager-load
       '@tryghost/bookshelf-filter':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../bookshelf-filter
       '@tryghost/bookshelf-has-posts':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../bookshelf-has-posts
       '@tryghost/bookshelf-include-count':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../bookshelf-include-count
       '@tryghost/bookshelf-order':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../bookshelf-order
       '@tryghost/bookshelf-pagination':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../bookshelf-pagination
       '@tryghost/bookshelf-search':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../bookshelf-search
       '@tryghost/bookshelf-transaction-events':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../bookshelf-transaction-events
     devDependencies:
       sinon:
@@ -256,7 +256,7 @@ importers:
   packages/config:
     dependencies:
       '@tryghost/root-utils':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../root-utils
       nconf:
         specifier: 0.13.0
@@ -271,7 +271,7 @@ importers:
   packages/debug:
     dependencies:
       '@tryghost/root-utils':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../root-utils
       debug:
         specifier: 4.4.3
@@ -280,7 +280,7 @@ importers:
   packages/domain-events:
     dependencies:
       '@tryghost/logging':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../logging
 
   packages/elasticsearch:
@@ -289,7 +289,7 @@ importers:
         specifier: 8.19.2
         version: 8.19.2(supports-color@8.1.1)
       '@tryghost/debug':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../debug
       split2:
         specifier: 4.2.0
@@ -326,7 +326,7 @@ importers:
   packages/express-test:
     dependencies:
       '@tryghost/jest-snapshot':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../jest-snapshot
       cookiejar:
         specifier: 2.1.4
@@ -360,10 +360,10 @@ importers:
   packages/http-stream:
     dependencies:
       '@tryghost/errors':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../errors
       '@tryghost/request':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../request
     devDependencies:
       express:
@@ -382,7 +382,7 @@ importers:
         specifier: 30.4.1
         version: 30.4.1
       '@tryghost/errors':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../errors
       jest-snapshot:
         specifier: 30.4.1
@@ -398,10 +398,10 @@ importers:
         specifier: 4.2.0
         version: 4.2.0
       '@tryghost/errors':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../errors
       '@tryghost/logging':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../logging
       bree:
         specifier: 9.2.9
@@ -435,19 +435,19 @@ importers:
   packages/logging:
     dependencies:
       '@tryghost/bunyan-rotating-filestream':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../bunyan-rotating-filestream
       '@tryghost/elasticsearch':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../elasticsearch
       '@tryghost/http-stream':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../http-stream
       '@tryghost/pretty-stream':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../pretty-stream
       '@tryghost/root-utils':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../root-utils
       bunyan:
         specifier: 1.8.15
@@ -466,7 +466,7 @@ importers:
         version: 4.18.1
     devDependencies:
       '@tryghost/errors':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../errors
       sinon:
         specifier: 'catalog:'
@@ -475,13 +475,13 @@ importers:
   packages/metrics:
     dependencies:
       '@tryghost/elasticsearch':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../elasticsearch
       '@tryghost/pretty-stream':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../pretty-stream
       '@tryghost/root-utils':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../root-utils
       json-stringify-safe:
         specifier: 5.0.1
@@ -497,16 +497,16 @@ importers:
   packages/mw-error-handler:
     dependencies:
       '@tryghost/debug':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../debug
       '@tryghost/errors':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../errors
       '@tryghost/http-cache-utils':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../http-cache-utils
       '@tryghost/tpl':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../tpl
       lodash:
         specifier: 4.18.1
@@ -531,10 +531,10 @@ importers:
         specifier: 3.1110.0
         version: 3.1110.0
       '@tryghost/errors':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../errors
       '@tryghost/tpl':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../tpl
       nodemailer:
         specifier: 9.0.5
@@ -582,10 +582,10 @@ importers:
   packages/prometheus-metrics:
     dependencies:
       '@tryghost/debug':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../debug
       '@tryghost/logging':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../logging
       express:
         specifier: 5.2.1
@@ -637,13 +637,13 @@ importers:
   packages/request:
     dependencies:
       '@tryghost/errors':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../errors
       '@tryghost/validator':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../validator
       '@tryghost/version':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../version
       cacheable-lookup:
         specifier: 7.0.0
@@ -694,10 +694,10 @@ importers:
   packages/server:
     dependencies:
       '@tryghost/debug':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../debug
       '@tryghost/logging':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../logging
     devDependencies:
       sinon:
@@ -716,10 +716,10 @@ importers:
   packages/validator:
     dependencies:
       '@tryghost/errors':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../errors
       '@tryghost/tpl':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../tpl
       lodash:
         specifier: 4.18.1
@@ -734,7 +734,7 @@ importers:
   packages/version:
     dependencies:
       '@tryghost/root-utils':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../root-utils
       semver:
         specifier: 7.8.5
@@ -760,7 +760,7 @@ importers:
   packages/zip:
     dependencies:
       '@tryghost/errors':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../errors
       archiver:
         specifier: 8.0.0


### PR DESCRIPTION
no ref
- this relaxes the cross-package requirements such that consumers of multiple packages don't end up with duplicate versions if they don't update all package requires in lockstep