### PR TITLE
✨ Added flush support to bunyan filestream

### DIFF
--- a/packages/bunyan-rotating-filestream/README.md
+++ b/packages/bunyan-rotating-filestream/README.md
@@ -37,6 +37,21 @@ const log = bunyan.createLogger({
 
 Other options include `startNewFile` to always open a new file on start-up.
 
+### Flushing
+
+Writes are queued and written asynchronously, so a process that exits right
+after logging can lose the last lines. `flush()` drains everything written so
+far to disk and leaves the stream open:
+
+```js
+log.error('fatal boot error');
+await stream.flush();
+process.exit(1);
+```
+
+Use `end()` instead when shutting the stream down for good — it also drains the
+queue, but closes the file handles and stops rotation.
+
 ## Develop
 
 This is a mono repository, managed with [Nx](https://nx.dev).

--- a/packages/bunyan-rotating-filestream/index.js
+++ b/packages/bunyan-rotating-filestream/index.js
@@ -61,6 +61,22 @@ class RotatingFileStream {
         this._queue.push(data);
     }
 
+    /**
+     * Force everything written into this stream so far out to disk, without
+     * closing it. The stream stays writable afterwards, unlike `end()`.
+     * @returns {Promise<void>}
+     */
+    async flush() {
+        if (this._closed) {
+            return;
+        }
+        await this._initialised;
+        // A rotation in progress owns the file handle - wait for it to hand
+        // the new one to the queue before draining
+        await this._rotating;
+        await this._queue.flush();
+    }
+
     async end() {
         // Block new rotations immediately - the threshold trigger has no timer
         // to shut down and can still fire while the queue drains below

--- a/packages/bunyan-rotating-filestream/lib/writeQueue.js
+++ b/packages/bunyan-rotating-filestream/lib/writeQueue.js
@@ -36,6 +36,28 @@ class WriteQueue extends EventEmitter {
         this._writing = this._write(currentEventCount);
     }
 
+    /**
+     * Drain everything queued so far, leaving the queue writable afterwards.
+     *
+     * Writes are asynchronous, so a process that exits right after logging
+     * (e.g. on a fatal boot error) can lose the lines still sitting in the
+     * queue. Unlike `shutdown()` this does not pause the queue, so it is safe
+     * to call at any point in the process lifetime.
+     * @returns {Promise<void>}
+     */
+    async flush() {
+        // The in-flight write owns the events it already spliced off the
+        // queue, so wait for it before queueing another write
+        await this._writing;
+
+        // A single write only takes the events present when it started, and
+        // anything pushed while it ran is not picked up until the next push
+        while (!this._paused && this._events.length) {
+            this.flushToDisk();
+            await this._writing;
+        }
+    }
+
     async pause() {
         this._paused = true;
         await this._writing;

--- a/packages/bunyan-rotating-filestream/test/filerotate.test.js
+++ b/packages/bunyan-rotating-filestream/test/filerotate.test.js
@@ -52,6 +52,34 @@ describe('RotatingFileStream', function () {
         await stream.end();
     });
 
+    it('Flushes queued logs to disk and stays writable', async function () {
+        const logPath = 'logs/flush.log';
+        const stream = new RotatingFileStream({
+            ...testConfig,
+            path: logPath,
+        });
+        const logger = bunyan.createLogger({
+            name: 'foo',
+            streams: [
+                {
+                    stream,
+                },
+            ],
+        });
+
+        logger.info('before flush');
+        await stream.flush();
+        assert.ok((await fs.readFile(logPath, 'utf8')).includes('before flush'));
+
+        logger.info('after flush');
+        await stream.flush();
+        assert.ok((await fs.readFile(logPath, 'utf8')).includes('after flush'));
+
+        await stream.end();
+        // Flushing a closed stream is a no-op
+        await stream.flush();
+    });
+
     it('Sets up period correctly', async function () {
         const stream = new RotatingFileStream({
             period: '1w',

--- a/packages/bunyan-rotating-filestream/test/units.test.js
+++ b/packages/bunyan-rotating-filestream/test/units.test.js
@@ -161,6 +161,40 @@ describe('WriteQueue', function () {
         await queue.shutdown();
     });
 
+    it('Flushes pending events without closing the queue', async function () {
+        const written = [];
+        const queue = new WriteQueue();
+        queue.setFileHandle({
+            write: async (data) => {
+                written.push(data);
+                return { bytesWritten: data.length };
+            },
+        });
+
+        queue.push('first\n');
+        // Pushed while the first write is in flight, so it is not picked up by
+        // that write and needs the flush loop to reach disk
+        queue.push('second\n');
+        await queue.flush();
+
+        assert.strictEqual(written.join(''), 'first\nsecond\n');
+
+        // Still writable afterwards
+        queue.push('third\n');
+        await queue.shutdown();
+        assert.strictEqual(written.join(''), 'first\nsecond\nthird\n');
+    });
+
+    it('Flushing an empty or paused queue is a no-op', async function () {
+        const queue = new WriteQueue();
+        await queue.flush();
+
+        // Never given a file handle, so the queue stays paused
+        queue.push('data\n');
+        await queue.flush();
+        await queue.shutdown();
+    });
+
     it('Reports bytes written', async function () {
         const queue = new WriteQueue();
         const written = [];

--- a/packages/logging/README.md
+++ b/packages/logging/README.md
@@ -28,6 +28,27 @@ const requestLogger = logging.child({ requestId: 'abc123' });
 requestLogger.warn('slow response');
 ```
 
+### Flushing before exit
+
+Transports that batch writes — ElasticSearch (buffered bulk requests) and the
+file transports (queued disk writes) — can still be holding log lines when a
+process exits, which is exactly when the last lines matter most. Await
+`flush()` before `process.exit()`:
+
+```js
+try {
+    await boot();
+} catch (err) {
+    logging.error(err);
+    await logging.flush();
+    process.exit(1);
+}
+```
+
+`flush()` never rejects and never closes a transport, so the logger stays
+usable afterwards. Transports that write straight through (stdout, stderr) are
+skipped.
+
 ### Types
 
 Types ship with the package. `GhostLogger` is exported as both a value (the

--- a/packages/logging/lib/GhostLogger.d.ts
+++ b/packages/logging/lib/GhostLogger.d.ts
@@ -122,9 +122,9 @@ declare class GhostLogger {
     fatal(...args: unknown[]): void;
 
     /**
-     * Flush buffered logs on any transport that batches writes (e.g.
-     * ElasticSearch), forcing them out before the process exits. Resolves once
-     * every flushable transport has drained; failures are swallowed.
+     * Flush buffered logs on any transport that batches writes (ElasticSearch,
+     * file), forcing them out before the process exits. Resolves once every
+     * flushable transport has drained; failures are swallowed.
      */
     flush(): Promise<void>;
 

--- a/packages/logging/lib/GhostLogger.js
+++ b/packages/logging/lib/GhostLogger.js
@@ -9,6 +9,46 @@ const fs = require('fs');
 const jsonStringifySafe = require('json-stringify-safe');
 
 /**
+ * @description Wait for a Node writable stream to hand everything it has
+ * buffered to the OS.
+ *
+ * A zero-length chunk queues behind any pending writes, so its callback only
+ * fires once those have been flushed.
+ * @param {any} stream
+ * @returns {Promise<void>}
+ */
+function drainWritable(stream) {
+    // Bunyan's own rotating-file stream wraps the real WriteStream
+    let writable = stream;
+    while (writable && typeof writable.writableLength !== 'number' && writable.stream) {
+        writable = writable.stream;
+    }
+
+    if (!writable || typeof writable.write !== 'function' || writable.writableEnded) {
+        return Promise.resolve();
+    }
+
+    return new Promise((resolve) => {
+        writable.write('', () => resolve());
+    });
+}
+
+/**
+ * @description Build a flushable transport for a bunyan logger whose streams
+ * are managed by bunyan itself (the `file` and `rotating-file` types), which
+ * buffer in memory like any other Node writable.
+ * @param {any} logger
+ * @returns {{flush(): Promise<void>}}
+ */
+function bunyanFileTransport(logger) {
+    return {
+        async flush() {
+            await Promise.all(logger.streams.map((stream) => drainWritable(stream.stream)));
+        },
+    };
+}
+
+/**
  * @description Ghost's logger class.
  *
  * The logger handles any stdout/stderr logs and streams it into the configured transports.
@@ -323,17 +363,23 @@ class GhostLogger {
                             : true,
                 };
 
+                const errorRotatingStream = new RotatingFileStream(
+                    Object.assign({}, rotationConfig, {
+                        path: `${this.path}${baseFilename}.error.log`,
+                    }),
+                );
+                const allRotatingStream = new RotatingFileStream(rotationConfig);
+
                 this.streams['rotation-errors'] = {
                     name: 'rotation-errors',
+                    // Keep a reference to the transport so `flush()` can drain
+                    // its write queue before the process exits
+                    transport: errorRotatingStream,
                     log: bunyan.createLogger({
                         name: this.name,
                         streams: [
                             {
-                                stream: new RotatingFileStream(
-                                    Object.assign({}, rotationConfig, {
-                                        path: `${this.path}${baseFilename}.error.log`,
-                                    }),
-                                ),
+                                stream: errorRotatingStream,
                                 level: 'error',
                             },
                         ],
@@ -343,11 +389,12 @@ class GhostLogger {
 
                 this.streams['rotation-all'] = {
                     name: 'rotation-all',
+                    transport: allRotatingStream,
                     log: bunyan.createLogger({
                         name: this.name,
                         streams: [
                             {
-                                stream: new RotatingFileStream(rotationConfig),
+                                stream: allRotatingStream,
                                 level: this.level,
                             },
                         ],
@@ -356,67 +403,77 @@ class GhostLogger {
                 };
             } else {
                 // TODO: Remove this when confidence is high in the external library for rotation
-                this.streams['rotation-errors'] = {
-                    name: 'rotation-errors',
-                    log: bunyan.createLogger({
-                        name: this.name,
-                        streams: [
-                            {
-                                type: 'rotating-file',
-                                path: `${this.path}${baseFilename}.error.log`,
-                                period: this.rotation.period,
-                                count: this.rotation.count,
-                                level: 'error',
-                            },
-                        ],
-                        serializers: this.serializers,
-                    }),
-                };
-
-                this.streams['rotation-all'] = {
-                    name: 'rotation-all',
-                    log: bunyan.createLogger({
-                        name: this.name,
-                        streams: [
-                            {
-                                type: 'rotating-file',
-                                path: `${this.path}${baseFilename}.log`,
-                                period: this.rotation.period,
-                                count: this.rotation.count,
-                                level: this.level,
-                            },
-                        ],
-                        serializers: this.serializers,
-                    }),
-                };
-            }
-        } else {
-            this.streams['file-errors'] = {
-                name: 'file',
-                log: bunyan.createLogger({
+                const errorRotatingLog = bunyan.createLogger({
                     name: this.name,
                     streams: [
                         {
+                            type: 'rotating-file',
                             path: `${this.path}${baseFilename}.error.log`,
+                            period: this.rotation.period,
+                            count: this.rotation.count,
                             level: 'error',
                         },
                     ],
                     serializers: this.serializers,
-                }),
-            };
-
-            this.streams['file-all'] = {
-                name: 'file',
-                log: bunyan.createLogger({
+                });
+                const allRotatingLog = bunyan.createLogger({
                     name: this.name,
                     streams: [
                         {
+                            type: 'rotating-file',
                             path: `${this.path}${baseFilename}.log`,
+                            period: this.rotation.period,
+                            count: this.rotation.count,
                             level: this.level,
                         },
                     ],
                     serializers: this.serializers,
-                }),
+                });
+
+                this.streams['rotation-errors'] = {
+                    name: 'rotation-errors',
+                    transport: bunyanFileTransport(errorRotatingLog),
+                    log: errorRotatingLog,
+                };
+
+                this.streams['rotation-all'] = {
+                    name: 'rotation-all',
+                    transport: bunyanFileTransport(allRotatingLog),
+                    log: allRotatingLog,
+                };
+            }
+        } else {
+            const errorFileLog = bunyan.createLogger({
+                name: this.name,
+                streams: [
+                    {
+                        path: `${this.path}${baseFilename}.error.log`,
+                        level: 'error',
+                    },
+                ],
+                serializers: this.serializers,
+            });
+            const allFileLog = bunyan.createLogger({
+                name: this.name,
+                streams: [
+                    {
+                        path: `${this.path}${baseFilename}.log`,
+                        level: this.level,
+                    },
+                ],
+                serializers: this.serializers,
+            });
+
+            this.streams['file-errors'] = {
+                name: 'file',
+                transport: bunyanFileTransport(errorFileLog),
+                log: errorFileLog,
+            };
+
+            this.streams['file-all'] = {
+                name: 'file',
+                transport: bunyanFileTransport(allFileLog),
+                log: allFileLog,
             };
         }
     }
@@ -602,15 +659,16 @@ class GhostLogger {
     /**
      * @description Flush buffered logs on any transport that batches writes.
      *
-     * Asynchronous transports (e.g. ElasticSearch) buffer log lines and only
-     * ship them on a size/time threshold or when their stream ends. On a fatal
-     * boot error the process exits before that threshold is reached, so the
-     * crash reason is never shipped. Awaiting `flush()` before `process.exit()`
-     * forces those buffers out.
+     * Asynchronous transports buffer log lines and only write them out on a
+     * size/time threshold, when their stream ends, or on the next tick. On a
+     * fatal boot error the process exits before that happens, so the crash
+     * reason is never persisted. Awaiting `flush()` before `process.exit()`
+     * forces those buffers out. This covers ElasticSearch (buffered bulk
+     * requests) and the file transports (queued/buffered disk writes).
      *
-     * Only transports exposing a `flush()` method are awaited; synchronous
-     * transports (stdout, stderr, file) have nothing to drain. Failures are
-     * swallowed so a broken transport can never block shutdown.
+     * Only transports exposing a `flush()` method are awaited; transports that
+     * write straight through (stdout, stderr) have nothing to drain. Failures
+     * are swallowed so a broken transport can never block shutdown.
      * @returns {Promise<void>}
      */
     async flush() {
@@ -648,6 +706,8 @@ class GhostLogger {
         result.streams = Object.keys(this.streams).reduce((acc, id) => {
             acc[id] = {
                 name: this.streams[id].name,
+                // Same underlying transport, so `flush()` works on children too
+                transport: this.streams[id].transport,
                 log: this.streams[id].log.child(boundProperties),
             };
             return acc;

--- a/packages/logging/test/logging.test.js
+++ b/packages/logging/test/logging.test.js
@@ -601,6 +601,107 @@ describe('Logging', function () {
             assert.notEqual(ghostLogger.streams['rotation-all'], undefined);
         });
 
+        it('flush writes buffered file logs to disk', async function () {
+            const tempDir = prepareTestLogDir('flush-file');
+
+            const ghostLogger = new GhostLogger({
+                domain: 'test.com',
+                env: 'production',
+                filename: '{env}',
+                transports: ['file'],
+                path: tempDir,
+            });
+
+            ghostLogger.error(new Error('boom'));
+
+            await ghostLogger.flush();
+
+            const errorLog = fs.readFileSync(path.join(tempDir, 'production.error.log'), 'utf8');
+            assert.equal(includes(errorLog, 'boom'), true);
+
+            fs.rmSync(tempDir, { recursive: true, force: true });
+        });
+
+        it('flush writes buffered logs from the rotation library to disk', async function () {
+            const tempDir = prepareTestLogDir('flush-rotation-library');
+
+            const ghostLogger = new GhostLogger({
+                domain: 'test.com',
+                env: 'production',
+                filename: '{env}',
+                transports: ['file'],
+                path: tempDir,
+                rotation: {
+                    enabled: true,
+                    useLibrary: true,
+                    period: '1d',
+                    threshold: '10m',
+                    count: 2,
+                },
+            });
+
+            ghostLogger.error(new Error('boom'));
+
+            await ghostLogger.flush();
+
+            const errorLog = fs.readFileSync(path.join(tempDir, 'production.error.log'), 'utf8');
+            assert.equal(includes(errorLog, 'boom'), true);
+
+            // The transports stay writable after a flush
+            await ghostLogger.streams['rotation-errors'].transport.end();
+            await ghostLogger.streams['rotation-all'].transport.end();
+            fs.rmSync(tempDir, { recursive: true, force: true });
+        });
+
+        it('flush writes buffered logs from the built-in rotation to disk', async function () {
+            const tempDir = prepareTestLogDir('flush-rotation-built-in');
+
+            const ghostLogger = new GhostLogger({
+                domain: 'test.com',
+                env: 'production',
+                filename: '{env}',
+                transports: ['file'],
+                path: tempDir,
+                rotation: {
+                    enabled: true,
+                    useLibrary: false,
+                    period: '1d',
+                    count: 2,
+                },
+            });
+
+            ghostLogger.error(new Error('boom'));
+
+            await ghostLogger.flush();
+
+            const errorLog = fs.readFileSync(path.join(tempDir, 'production.error.log'), 'utf8');
+            assert.equal(includes(errorLog, 'boom'), true);
+
+            fs.rmSync(tempDir, { recursive: true, force: true });
+        });
+
+        it('child loggers keep the flushable transports of their parent', async function () {
+            const tempDir = prepareTestLogDir('flush-child');
+
+            const ghostLogger = new GhostLogger({
+                domain: 'test.com',
+                env: 'production',
+                filename: '{env}',
+                transports: ['file'],
+                path: tempDir,
+            });
+
+            const child = ghostLogger.child({ requestId: 'abc123' });
+            child.error(new Error('boom'));
+
+            await child.flush();
+
+            const errorLog = fs.readFileSync(path.join(tempDir, 'production.error.log'), 'utf8');
+            assert.equal(includes(errorLog, 'abc123'), true);
+
+            fs.rmSync(tempDir, { recursive: true, force: true });
+        });
+
         it('file stream exits early when target directory does not exist', function () {
             const badPath = getTestLogDir('missing-dir');
             fs.rmSync(badPath, { recursive: true, force: true });


### PR DESCRIPTION
ref https://linear.app/ghost/issue/ONC-1954
- Ghost doesn't use elasticsearch log shipping in production, it writes to a file and then filebeat ships to Elastic
- as such, the elasticsearch log flush didn't do anything, flush was needed on rotating filestream instead