### PR TITLE
🏗 Replaced remaining dynamic ESM imports with require()

### DIFF
--- a/packages/job-manager/lib/JobManager.js
+++ b/packages/job-manager/lib/JobManager.js
@@ -4,6 +4,7 @@ const setTimeoutPromise = util.promisify(setTimeout);
 const fastq = require('fastq');
 const later = require('@breejs/later');
 const Bree = require('bree');
+const pWaitFor = require('p-wait-for').default;
 const { UnhandledJobError, IncorrectUsageError } = require('@tryghost/errors');
 const logging = require('@tryghost/logging');
 const isCronExpression = require('./is-cron-expression');
@@ -426,7 +427,6 @@ class JobManager {
 
         logging.warn('Waiting for busy job in inline job queue');
 
-        const { default: pWaitFor } = await import('p-wait-for');
         await pWaitFor(() => this.inlineQueue.idle() === true, options);
 
         logging.warn('Inline job queue finished');

--- a/packages/job-manager/package.json
+++ b/packages/job-manager/package.json
@@ -36,5 +36,8 @@
     "date-fns": "4.4.0",
     "rewire": "9.0.1",
     "sinon": "catalog:"
+  },
+  "engines": {
+    "node": "^22.12.0 || >=24.0.0"
   }
 }

--- a/packages/webhook-mock-receiver/lib/WebhookMockReceiver.js
+++ b/packages/webhook-mock-receiver/lib/WebhookMockReceiver.js
@@ -1,6 +1,7 @@
 const { AssertionError } = require('assert');
 const { URL } = require('url');
 const nock = require('nock');
+const pWaitFor = require('p-wait-for').default;
 class WebhookMockReceiver {
     constructor({ snapshotManager }) {
         this.snapshotManager = snapshotManager;
@@ -14,7 +15,6 @@ class WebhookMockReceiver {
 
     async receivedRequest() {
         // @NOTE: figure out a better waiting mechanism here, don't allow it to hang forever
-        const { default: pWaitFor } = await import('p-wait-for');
         await pWaitFor(() => this._receiver.isDone());
     }
 

--- a/packages/webhook-mock-receiver/package.json
+++ b/packages/webhook-mock-receiver/package.json
@@ -26,7 +26,10 @@
     "p-wait-for": "6.0.0"
   },
   "devDependencies": {
-    "got": "14.6.6",
+    "got": "15.1.0",
     "sinon": "catalog:"
+  },
+  "engines": {
+    "node": "^22.12.0 || >=24.0.0"
   }
 }

--- a/packages/webhook-mock-receiver/test/WebhookMockReceiver.test.js
+++ b/packages/webhook-mock-receiver/test/WebhookMockReceiver.test.js
@@ -2,15 +2,14 @@ const assert = require('assert/strict');
 const sinon = require('sinon');
 
 const WebhookMockReceiver = require('../');
+const got = require('got').default;
 
 describe('Webhook Mock Receiver', function () {
     let snapshotManager;
     let webhookMockReceiver;
-    let got;
     const webhookURL = 'https://test-webhook-receiver.com/webhook';
 
-    beforeAll(async function () {
-        got = (await import('got')).default;
+    beforeAll(function () {
         snapshotManager = {
             assertSnapshot: sinon.spy(),
         };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -751,8 +751,8 @@ importers:
         version: 6.0.0
     devDependencies:
       got:
-        specifier: 14.6.6
-        version: 14.6.6
+        specifier: 15.1.0
+        version: 15.1.0
       sinon:
         specifier: 'catalog:'
         version: 22.1.0
@@ -2234,10 +2234,6 @@ packages:
   '@sinclair/typebox@0.34.52':
     resolution: {integrity: sha512-XiMQh7qqVlxZzcVD+kkGMNGMzcTrDMLWI7S4x7z1MkCkbDPrekpZXEUK0eZqZFMuHQg2a2DZOcDIh9o5v3Gonw==}
 
-  '@sindresorhus/is@7.2.0':
-    resolution: {integrity: sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==}
-    engines: {node: '>=18'}
-
   '@sindresorhus/is@8.1.0':
     resolution: {integrity: sha512-2SX/1jW6CIMAiebvVv5ZInoCEuWQmMyBoJXXGC6Vjakjp/fpxP5eHs7/V6WKuPEIbuK06+VpjH+vjLQhr98rDQ==}
     engines: {node: '>=22'}
@@ -3560,10 +3556,6 @@ packages:
       debug:
         optional: true
 
-  form-data-encoder@4.1.0:
-    resolution: {integrity: sha512-G6NsmEW15s0Uw9XnCg+33H3ViYRyiM0hMrMhhqQOR8NFc5GhYrI+6I3u7OTw7b91J2g8rtvMBZJDbcGb2YUniw==}
-    engines: {node: '>= 18'}
-
   form-data@4.0.6:
     resolution: {integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==}
     engines: {node: '>= 6'}
@@ -3657,10 +3649,6 @@ packages:
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
-
-  got@14.6.6:
-    resolution: {integrity: sha512-QLV1qeYSo5l13mQzWgP/y0LbMr5Plr5fJilgAIwgnwseproEbtNym8xpLsDzeZ6MWXgNE6kdWGBjdh3zT/Qerg==}
-    engines: {node: '>=20'}
 
   got@15.1.0:
     resolution: {integrity: sha512-DG+DAAkRtno+oDr/GBsliAkhN9+zczOPM5qXk3efDZY3qvyRnZU+NwQlb/IOY6cSnxxTR9z3aHCcShJyjb0hJA==}
@@ -4422,10 +4410,6 @@ packages:
       vite-plus:
         optional: true
 
-  p-cancelable@4.0.1:
-    resolution: {integrity: sha512-wBowNApzd45EIKdO1LaU+LrMBwAcjfPaYtVzV3lmfM3gf8Z4CHZsiIqlM8TZZ8okYvh5A1cP6gTfCRQtwUpaUg==}
-    engines: {node: '>=14.16'}
-
   p-finally@1.0.0:
     resolution: {integrity: sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==}
     engines: {node: '>=4'}
@@ -5010,10 +4994,6 @@ packages:
   type-fest@2.19.0:
     resolution: {integrity: sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==}
     engines: {node: '>=12.20'}
-
-  type-fest@4.41.0:
-    resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
-    engines: {node: '>=16'}
 
   type-fest@5.8.0:
     resolution: {integrity: sha512-YGYEVz3Fm5iy/AybuA0oyNFq7H4CgQNfRp/qfe8nurE1kuCeNm3/vfm9X4Mtl+qLyaKJUh5xrFZwogr41SMjYA==}
@@ -6861,8 +6841,6 @@ snapshots:
 
   '@sinclair/typebox@0.34.52': {}
 
-  '@sindresorhus/is@7.2.0': {}
-
   '@sindresorhus/is@8.1.0': {}
 
   '@sinonjs/commons@3.0.1':
@@ -8094,8 +8072,6 @@ snapshots:
     optionalDependencies:
       debug: 4.4.3(supports-color@7.2.0)
 
-  form-data-encoder@4.1.0: {}
-
   form-data@4.0.6:
     dependencies:
       asynckit: 0.4.0
@@ -8197,21 +8173,6 @@ snapshots:
   globals@14.0.0: {}
 
   gopd@1.2.0: {}
-
-  got@14.6.6:
-    dependencies:
-      '@sindresorhus/is': 7.2.0
-      byte-counter: 0.1.0
-      cacheable-lookup: 7.0.0
-      cacheable-request: 13.0.19
-      decompress-response: 10.0.0
-      form-data-encoder: 4.1.0
-      http2-wrapper: 2.2.1
-      keyv: 5.6.0
-      lowercase-keys: 3.0.0
-      p-cancelable: 4.0.1
-      responselike: 4.0.2
-      type-fest: 4.41.0
 
   got@15.1.0:
     dependencies:
@@ -9147,8 +9108,6 @@ snapshots:
       '@oxlint/binding-win32-ia32-msvc': 1.80.0
       '@oxlint/binding-win32-x64-msvc': 1.80.0
 
-  p-cancelable@4.0.1: {}
-
   p-finally@1.0.0: {}
 
   p-limit@2.3.0:
@@ -9764,8 +9723,6 @@ snapshots:
   type-detect@4.1.0: {}
 
   type-fest@2.19.0: {}
-
-  type-fest@4.41.0: {}
 
   type-fest@5.8.0:
     dependencies:


### PR DESCRIPTION
Follow-up to #953.

`JobManager` and `WebhookMockReceiver` both loaded `p-wait-for` via `await import()` inside a method — a leftover from before Node supported `require()` of ESM.

Unlike `@tryghost/request`, neither had the actual bug: they await at the call site instead of caching a module-scope promise, so the module is never left half-loaded across arbitrary consumer code. The window is just the import's own I/O, and nothing in the repo requires `p-wait-for` synchronously. This is cleanup, not a fix — it removes the last of the pattern from library code.

## Changes

- Load `p-wait-for` with `require()` at module scope in `job-manager` and `webhook-mock-receiver`
- Declare `"engines": { "node": "^22.12.0 || >=24.0.0" }` on both, matching #953 — `require(esm)` was flagged before 22.12
- Align `got` on 15.1.0 in `webhook-mock-receiver` to match `@tryghost/request`, and drop the `await import('got')` in its tests

`got` is a test-only dependency in `webhook-mock-receiver`, so the bump carries no runtime risk. Left it as a literal version rather than moving both packages to a `catalog:` entry — `nx release publish` shells out to npm, and I didn't want to bet a published runtime dependency on the `catalog:` protocol being rewritten at pack time.

## Testing

Both suites pass on Node 22 and Node 24: job-manager 40 passed (1 todo), webhook-mock-receiver 8 passed at 100% coverage. Lint and format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)