### PR TITLE
Use caret ranges for published runtime dependencies

### DIFF
--- a/packages/api-framework/package.json
+++ b/packages/api-framework/package.json
@@ -26,7 +26,7 @@
     "@tryghost/promise": "workspace:^",
     "@tryghost/tpl": "workspace:^",
     "@tryghost/validator": "workspace:^",
-    "lodash": "4.18.1"
+    "lodash": "^4.18.1"
   },
   "devDependencies": {
     "sinon": "catalog:"

--- a/packages/bookshelf-collision/package.json
+++ b/packages/bookshelf-collision/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "@tryghost/errors": "workspace:^",
-    "lodash": "4.18.1",
+    "lodash": "^4.18.1",
     "moment-timezone": "^0.5.33"
   },
   "devDependencies": {

--- a/packages/bookshelf-eager-load/package.json
+++ b/packages/bookshelf-eager-load/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "@tryghost/debug": "workspace:^",
-    "lodash": "4.18.1"
+    "lodash": "^4.18.1"
   },
   "devDependencies": {
     "sinon": "catalog:"

--- a/packages/bookshelf-filter/package.json
+++ b/packages/bookshelf-filter/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "@tryghost/debug": "workspace:^",
     "@tryghost/errors": "workspace:^",
-    "@tryghost/nql": "0.13.4",
+    "@tryghost/nql": "^0.13.4",
     "@tryghost/tpl": "workspace:^"
   },
   "devDependencies": {

--- a/packages/bookshelf-has-posts/package.json
+++ b/packages/bookshelf-has-posts/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "@tryghost/debug": "workspace:^",
-    "lodash": "4.18.1"
+    "lodash": "^4.18.1"
   },
   "devDependencies": {
     "sinon": "catalog:"

--- a/packages/bookshelf-include-count/package.json
+++ b/packages/bookshelf-include-count/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "@tryghost/debug": "workspace:^",
-    "lodash": "4.18.1"
+    "lodash": "^4.18.1"
   },
   "devDependencies": {
     "sinon": "catalog:"

--- a/packages/bookshelf-order/package.json
+++ b/packages/bookshelf-order/package.json
@@ -23,7 +23,7 @@
     "posttest": "pnpm run lint"
   },
   "dependencies": {
-    "lodash": "4.18.1"
+    "lodash": "^4.18.1"
   },
   "devDependencies": {
     "sinon": "catalog:"

--- a/packages/bookshelf-pagination/package.json
+++ b/packages/bookshelf-pagination/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "@tryghost/errors": "workspace:^",
     "@tryghost/tpl": "workspace:^",
-    "lodash": "4.18.1"
+    "lodash": "^4.18.1"
   },
   "devDependencies": {
     "bookshelf": "1.2.0",

--- a/packages/bunyan-rotating-filestream/package.json
+++ b/packages/bunyan-rotating-filestream/package.json
@@ -24,7 +24,7 @@
     "posttest": "pnpm run lint"
   },
   "dependencies": {
-    "long-timeout": "0.1.1"
+    "long-timeout": "^0.1.1"
   },
   "devDependencies": {
     "bunyan": "1.8.15",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -24,6 +24,6 @@
   },
   "dependencies": {
     "@tryghost/root-utils": "workspace:^",
-    "nconf": "0.13.0"
+    "nconf": "^0.13.0"
   }
 }

--- a/packages/debug/package.json
+++ b/packages/debug/package.json
@@ -26,6 +26,6 @@
   },
   "dependencies": {
     "@tryghost/root-utils": "workspace:^",
-    "debug": "4.4.3"
+    "debug": "^4.4.3"
   }
 }

--- a/packages/elasticsearch/package.json
+++ b/packages/elasticsearch/package.json
@@ -23,9 +23,9 @@
     "posttest": "pnpm run lint"
   },
   "dependencies": {
-    "@elastic/elasticsearch": "8.19.2",
+    "@elastic/elasticsearch": "^8.19.2",
     "@tryghost/debug": "workspace:^",
-    "split2": "4.2.0"
+    "split2": "^4.2.0"
   },
   "devDependencies": {
     "sinon": "catalog:"

--- a/packages/express-test/package.json
+++ b/packages/express-test/package.json
@@ -24,9 +24,9 @@
   },
   "dependencies": {
     "@tryghost/jest-snapshot": "workspace:^",
-    "cookiejar": "2.1.4",
-    "form-data": "4.0.6",
-    "mime-types": "3.0.2"
+    "cookiejar": "^2.1.4",
+    "form-data": "^4.0.6",
+    "mime-types": "^3.0.2"
   },
   "devDependencies": {
     "express": "5.2.1",

--- a/packages/jest-snapshot/package.json
+++ b/packages/jest-snapshot/package.json
@@ -23,10 +23,10 @@
     "posttest": "pnpm run lint"
   },
   "dependencies": {
-    "@jest/expect": "30.4.1",
-    "@jest/expect-utils": "30.4.1",
+    "@jest/expect": "^30.4.1",
+    "@jest/expect-utils": "^30.4.1",
     "@tryghost/errors": "workspace:^",
-    "jest-snapshot": "30.4.1"
+    "jest-snapshot": "^30.4.1"
   },
   "devDependencies": {
     "sinon": "catalog:"

--- a/packages/job-manager/package.json
+++ b/packages/job-manager/package.json
@@ -22,14 +22,14 @@
     "lint": "oxlint -c ../../.oxlintrc.json ."
   },
   "dependencies": {
-    "@breejs/later": "4.2.0",
+    "@breejs/later": "^4.2.0",
     "@tryghost/errors": "workspace:^",
     "@tryghost/logging": "workspace:^",
-    "bree": "9.2.9",
-    "cron-validate": "1.5.3",
-    "fastq": "1.20.3",
-    "p-wait-for": "6.0.0",
-    "workerpool": "10.0.3"
+    "bree": "^9.2.9",
+    "cron-validate": "^1.5.3",
+    "fastq": "^1.20.3",
+    "p-wait-for": "^6.0.0",
+    "workerpool": "^10.0.3"
   },
   "devDependencies": {
     "@sinonjs/fake-timers": "15.4.0",

--- a/packages/logging/package.json
+++ b/packages/logging/package.json
@@ -30,11 +30,11 @@
     "@tryghost/http-stream": "workspace:^",
     "@tryghost/pretty-stream": "workspace:^",
     "@tryghost/root-utils": "workspace:^",
-    "bunyan": "1.8.15",
-    "fs-extra": "11.4.0",
-    "gelf-stream": "1.1.1",
-    "json-stringify-safe": "5.0.1",
-    "lodash": "4.18.1"
+    "bunyan": "^1.8.15",
+    "fs-extra": "^11.4.0",
+    "gelf-stream": "^1.1.1",
+    "json-stringify-safe": "^5.0.1",
+    "lodash": "^4.18.1"
   },
   "devDependencies": {
     "@tryghost/errors": "workspace:^",

--- a/packages/metrics/package.json
+++ b/packages/metrics/package.json
@@ -28,7 +28,7 @@
     "@tryghost/elasticsearch": "workspace:^",
     "@tryghost/pretty-stream": "workspace:^",
     "@tryghost/root-utils": "workspace:^",
-    "json-stringify-safe": "5.0.1"
+    "json-stringify-safe": "^5.0.1"
   },
   "devDependencies": {
     "rewire": "9.0.1",

--- a/packages/mw-error-handler/package.json
+++ b/packages/mw-error-handler/package.json
@@ -27,8 +27,8 @@
     "@tryghost/errors": "workspace:^",
     "@tryghost/http-cache-utils": "workspace:^",
     "@tryghost/tpl": "workspace:^",
-    "lodash": "4.18.1",
-    "semver": "7.8.5"
+    "lodash": "^4.18.1",
+    "semver": "^7.8.5"
   },
   "devDependencies": {
     "sinon": "catalog:"

--- a/packages/nodemailer/package.json
+++ b/packages/nodemailer/package.json
@@ -23,12 +23,12 @@
     "posttest": "pnpm run lint"
   },
   "dependencies": {
-    "@aws-sdk/client-sesv2": "3.1122.0",
+    "@aws-sdk/client-sesv2": "^3.1122.0",
     "@tryghost/errors": "workspace:^",
     "@tryghost/tpl": "workspace:^",
-    "nodemailer": "9.1.0",
-    "nodemailer-mailgun-transport": "2.1.5",
-    "nodemailer-stub-transport": "1.1.0"
+    "nodemailer": "^9.1.0",
+    "nodemailer-mailgun-transport": "^2.1.5",
+    "nodemailer-stub-transport": "^1.1.0"
   },
   "devDependencies": {
     "sinon": "catalog:"

--- a/packages/pretty-cli/package.json
+++ b/packages/pretty-cli/package.json
@@ -24,8 +24,8 @@
     "posttest": "pnpm run lint"
   },
   "dependencies": {
-    "chalk": "6.0.0",
-    "sywac": "1.3.0"
+    "chalk": "^6.0.0",
+    "sywac": "^1.3.0"
   },
   "devDependencies": {
     "sinon": "catalog:"

--- a/packages/pretty-stream/package.json
+++ b/packages/pretty-stream/package.json
@@ -25,9 +25,9 @@
     "posttest": "pnpm run lint"
   },
   "dependencies": {
-    "date-format": "4.0.14",
-    "lodash": "4.18.1",
-    "prettyjson": "1.2.5"
+    "date-format": "^4.0.14",
+    "lodash": "^4.18.1",
+    "prettyjson": "^1.2.5"
   },
   "devDependencies": {
     "sinon": "catalog:"

--- a/packages/prometheus-metrics/package.json
+++ b/packages/prometheus-metrics/package.json
@@ -28,9 +28,9 @@
   "dependencies": {
     "@tryghost/debug": "workspace:^",
     "@tryghost/logging": "workspace:^",
-    "express": "5.2.1",
-    "prom-client": "15.1.3",
-    "stoppable": "1.1.0"
+    "express": "^5.2.1",
+    "prom-client": "^15.1.3",
+    "stoppable": "^1.1.0"
   },
   "devDependencies": {
     "@types/express": "5.0.6",

--- a/packages/request/package.json
+++ b/packages/request/package.json
@@ -26,9 +26,9 @@
     "@tryghost/errors": "workspace:^",
     "@tryghost/validator": "workspace:^",
     "@tryghost/version": "workspace:^",
-    "cacheable-lookup": "7.0.0",
-    "got": "16.0.0",
-    "lodash": "4.18.1"
+    "cacheable-lookup": "^7.0.0",
+    "got": "^16.0.0",
+    "lodash": "^4.18.1"
   },
   "devDependencies": {
     "nock": "14.0.17",

--- a/packages/root-utils/package.json
+++ b/packages/root-utils/package.json
@@ -23,8 +23,8 @@
     "posttest": "pnpm run lint"
   },
   "dependencies": {
-    "caller": "1.1.0",
-    "find-root": "1.1.0"
+    "caller": "^1.1.0",
+    "find-root": "^1.1.0"
   },
   "devDependencies": {
     "sinon": "catalog:"

--- a/packages/security/package.json
+++ b/packages/security/package.json
@@ -23,8 +23,8 @@
     "lint": "oxlint -c ../../.oxlintrc.json ."
   },
   "dependencies": {
-    "@tryghost/string": "0.3.5",
-    "bcryptjs": "3.0.3"
+    "@tryghost/string": "^0.3.5",
+    "bcryptjs": "^3.0.3"
   },
   "devDependencies": {
     "sinon": "catalog:"

--- a/packages/validator/package.json
+++ b/packages/validator/package.json
@@ -25,8 +25,8 @@
   "dependencies": {
     "@tryghost/errors": "workspace:^",
     "@tryghost/tpl": "workspace:^",
-    "lodash": "4.18.1",
+    "lodash": "^4.18.1",
     "moment-timezone": "^0.5.23",
-    "validator": "13.15.35"
+    "validator": "^13.15.35"
   }
 }

--- a/packages/version/package.json
+++ b/packages/version/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "@tryghost/root-utils": "workspace:^",
-    "semver": "7.8.5"
+    "semver": "^7.8.5"
   },
   "devDependencies": {
     "sinon": "catalog:"

--- a/packages/webhook-mock-receiver/package.json
+++ b/packages/webhook-mock-receiver/package.json
@@ -23,7 +23,7 @@
     "posttest": "pnpm run lint"
   },
   "dependencies": {
-    "p-wait-for": "6.0.0"
+    "p-wait-for": "^6.0.0"
   },
   "devDependencies": {
     "got": "16.0.0",

--- a/packages/zip/package.json
+++ b/packages/zip/package.json
@@ -24,8 +24,8 @@
   },
   "dependencies": {
     "@tryghost/errors": "workspace:^",
-    "archiver": "8.0.0",
-    "extract-zip": "2.0.1"
+    "archiver": "^8.0.0",
+    "extract-zip": "^2.0.1"
   },
   "devDependencies": {
     "folder-hash": "4.1.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,7 +69,7 @@ importers:
         specifier: workspace:^
         version: link:../validator
       lodash:
-        specifier: 4.18.1
+        specifier: ^4.18.1
         version: 4.18.1
     devDependencies:
       sinon:
@@ -82,7 +82,7 @@ importers:
         specifier: workspace:^
         version: link:../errors
       lodash:
-        specifier: 4.18.1
+        specifier: ^4.18.1
         version: 4.18.1
       moment-timezone:
         specifier: ^0.5.33
@@ -104,7 +104,7 @@ importers:
         specifier: workspace:^
         version: link:../debug
       lodash:
-        specifier: 4.18.1
+        specifier: ^4.18.1
         version: 4.18.1
     devDependencies:
       sinon:
@@ -120,7 +120,7 @@ importers:
         specifier: workspace:^
         version: link:../errors
       '@tryghost/nql':
-        specifier: 0.13.4
+        specifier: ^0.13.4
         version: 0.13.4(supports-color@8.1.1)
       '@tryghost/tpl':
         specifier: workspace:^
@@ -136,7 +136,7 @@ importers:
         specifier: workspace:^
         version: link:../debug
       lodash:
-        specifier: 4.18.1
+        specifier: ^4.18.1
         version: 4.18.1
     devDependencies:
       sinon:
@@ -149,7 +149,7 @@ importers:
         specifier: workspace:^
         version: link:../debug
       lodash:
-        specifier: 4.18.1
+        specifier: ^4.18.1
         version: 4.18.1
     devDependencies:
       sinon:
@@ -159,7 +159,7 @@ importers:
   packages/bookshelf-order:
     dependencies:
       lodash:
-        specifier: 4.18.1
+        specifier: ^4.18.1
         version: 4.18.1
     devDependencies:
       sinon:
@@ -175,7 +175,7 @@ importers:
         specifier: workspace:^
         version: link:../tpl
       lodash:
-        specifier: 4.18.1
+        specifier: ^4.18.1
         version: 4.18.1
     devDependencies:
       bookshelf:
@@ -243,7 +243,7 @@ importers:
   packages/bunyan-rotating-filestream:
     dependencies:
       long-timeout:
-        specifier: 0.1.1
+        specifier: ^0.1.1
         version: 0.1.1
     devDependencies:
       bunyan:
@@ -259,7 +259,7 @@ importers:
         specifier: workspace:^
         version: link:../root-utils
       nconf:
-        specifier: 0.13.0
+        specifier: ^0.13.0
         version: 0.13.0
 
   packages/database-info:
@@ -274,7 +274,7 @@ importers:
         specifier: workspace:^
         version: link:../root-utils
       debug:
-        specifier: 4.4.3
+        specifier: ^4.4.3
         version: 4.4.3(supports-color@8.1.1)
 
   packages/domain-events:
@@ -286,13 +286,13 @@ importers:
   packages/elasticsearch:
     dependencies:
       '@elastic/elasticsearch':
-        specifier: 8.19.2
+        specifier: ^8.19.2
         version: 8.19.2(supports-color@8.1.1)
       '@tryghost/debug':
         specifier: workspace:^
         version: link:../debug
       split2:
-        specifier: 4.2.0
+        specifier: ^4.2.0
         version: 4.2.0
     devDependencies:
       sinon:
@@ -329,13 +329,13 @@ importers:
         specifier: workspace:^
         version: link:../jest-snapshot
       cookiejar:
-        specifier: 2.1.4
+        specifier: ^2.1.4
         version: 2.1.4
       form-data:
-        specifier: 4.0.6
+        specifier: ^4.0.6
         version: 4.0.6
       mime-types:
-        specifier: 3.0.2
+        specifier: ^3.0.2
         version: 3.0.2
     devDependencies:
       express:
@@ -376,16 +376,16 @@ importers:
   packages/jest-snapshot:
     dependencies:
       '@jest/expect':
-        specifier: 30.4.1
+        specifier: ^30.4.1
         version: 30.4.1(supports-color@8.1.1)
       '@jest/expect-utils':
-        specifier: 30.4.1
+        specifier: ^30.4.1
         version: 30.4.1
       '@tryghost/errors':
         specifier: workspace:^
         version: link:../errors
       jest-snapshot:
-        specifier: 30.4.1
+        specifier: ^30.4.1
         version: 30.4.1(supports-color@8.1.1)
     devDependencies:
       sinon:
@@ -395,7 +395,7 @@ importers:
   packages/job-manager:
     dependencies:
       '@breejs/later':
-        specifier: 4.2.0
+        specifier: ^4.2.0
         version: 4.2.0
       '@tryghost/errors':
         specifier: workspace:^
@@ -404,19 +404,19 @@ importers:
         specifier: workspace:^
         version: link:../logging
       bree:
-        specifier: 9.2.9
+        specifier: ^9.2.9
         version: 9.2.9
       cron-validate:
-        specifier: 1.5.3
+        specifier: ^1.5.3
         version: 1.5.3
       fastq:
-        specifier: 1.20.3
+        specifier: ^1.20.3
         version: 1.20.3
       p-wait-for:
-        specifier: 6.0.0
+        specifier: ^6.0.0
         version: 6.0.0
       workerpool:
-        specifier: 10.0.3
+        specifier: ^10.0.3
         version: 10.0.3
     devDependencies:
       '@sinonjs/fake-timers':
@@ -450,19 +450,19 @@ importers:
         specifier: workspace:^
         version: link:../root-utils
       bunyan:
-        specifier: 1.8.15
+        specifier: ^1.8.15
         version: 1.8.15
       fs-extra:
-        specifier: 11.4.0
+        specifier: ^11.4.0
         version: 11.4.0
       gelf-stream:
-        specifier: 1.1.1
+        specifier: ^1.1.1
         version: 1.1.1
       json-stringify-safe:
-        specifier: 5.0.1
+        specifier: ^5.0.1
         version: 5.0.1
       lodash:
-        specifier: 4.18.1
+        specifier: ^4.18.1
         version: 4.18.1
     devDependencies:
       '@tryghost/errors':
@@ -484,7 +484,7 @@ importers:
         specifier: workspace:^
         version: link:../root-utils
       json-stringify-safe:
-        specifier: 5.0.1
+        specifier: ^5.0.1
         version: 5.0.1
     devDependencies:
       rewire:
@@ -509,10 +509,10 @@ importers:
         specifier: workspace:^
         version: link:../tpl
       lodash:
-        specifier: 4.18.1
+        specifier: ^4.18.1
         version: 4.18.1
       semver:
-        specifier: 7.8.5
+        specifier: ^7.8.5
         version: 7.8.5
     devDependencies:
       sinon:
@@ -528,7 +528,7 @@ importers:
   packages/nodemailer:
     dependencies:
       '@aws-sdk/client-sesv2':
-        specifier: 3.1122.0
+        specifier: ^3.1122.0
         version: 3.1122.0
       '@tryghost/errors':
         specifier: workspace:^
@@ -537,13 +537,13 @@ importers:
         specifier: workspace:^
         version: link:../tpl
       nodemailer:
-        specifier: 9.1.0
+        specifier: ^9.1.0
         version: 9.1.0
       nodemailer-mailgun-transport:
-        specifier: 2.1.5
+        specifier: ^2.1.5
         version: 2.1.5(debug@4.4.3(supports-color@7.2.0))(lodash@4.18.1)(supports-color@7.2.0)
       nodemailer-stub-transport:
-        specifier: 1.1.0
+        specifier: ^1.1.0
         version: 1.1.0
     devDependencies:
       sinon:
@@ -553,10 +553,10 @@ importers:
   packages/pretty-cli:
     dependencies:
       chalk:
-        specifier: 6.0.0
+        specifier: ^6.0.0
         version: 6.0.0
       sywac:
-        specifier: 1.3.0
+        specifier: ^1.3.0
         version: 1.3.0
     devDependencies:
       sinon:
@@ -566,13 +566,13 @@ importers:
   packages/pretty-stream:
     dependencies:
       date-format:
-        specifier: 4.0.14
+        specifier: ^4.0.14
         version: 4.0.14
       lodash:
-        specifier: 4.18.1
+        specifier: ^4.18.1
         version: 4.18.1
       prettyjson:
-        specifier: 1.2.5
+        specifier: ^1.2.5
         version: 1.2.5
     devDependencies:
       sinon:
@@ -588,13 +588,13 @@ importers:
         specifier: workspace:^
         version: link:../logging
       express:
-        specifier: 5.2.1
+        specifier: ^5.2.1
         version: 5.2.1(supports-color@8.1.1)
       prom-client:
-        specifier: 15.1.3
+        specifier: ^15.1.3
         version: 15.1.3
       stoppable:
-        specifier: 1.1.0
+        specifier: ^1.1.0
         version: 1.1.0
     devDependencies:
       '@types/express':
@@ -646,13 +646,13 @@ importers:
         specifier: workspace:^
         version: link:../version
       cacheable-lookup:
-        specifier: 7.0.0
+        specifier: ^7.0.0
         version: 7.0.0
       got:
-        specifier: 16.0.0
+        specifier: ^16.0.0
         version: 16.0.0
       lodash:
-        specifier: 4.18.1
+        specifier: ^4.18.1
         version: 4.18.1
     devDependencies:
       nock:
@@ -668,10 +668,10 @@ importers:
   packages/root-utils:
     dependencies:
       caller:
-        specifier: 1.1.0
+        specifier: ^1.1.0
         version: 1.1.0
       find-root:
-        specifier: 1.1.0
+        specifier: ^1.1.0
         version: 1.1.0
     devDependencies:
       sinon:
@@ -681,10 +681,10 @@ importers:
   packages/security:
     dependencies:
       '@tryghost/string':
-        specifier: 0.3.5
+        specifier: ^0.3.5
         version: 0.3.5
       bcryptjs:
-        specifier: 3.0.3
+        specifier: ^3.0.3
         version: 3.0.3
     devDependencies:
       sinon:
@@ -722,13 +722,13 @@ importers:
         specifier: workspace:^
         version: link:../tpl
       lodash:
-        specifier: 4.18.1
+        specifier: ^4.18.1
         version: 4.18.1
       moment-timezone:
         specifier: ^0.5.23
         version: 0.5.48
       validator:
-        specifier: 13.15.35
+        specifier: ^13.15.35
         version: 13.15.35
 
   packages/version:
@@ -737,7 +737,7 @@ importers:
         specifier: workspace:^
         version: link:../root-utils
       semver:
-        specifier: 7.8.5
+        specifier: ^7.8.5
         version: 7.8.5
     devDependencies:
       sinon:
@@ -747,7 +747,7 @@ importers:
   packages/webhook-mock-receiver:
     dependencies:
       p-wait-for:
-        specifier: 6.0.0
+        specifier: ^6.0.0
         version: 6.0.0
     devDependencies:
       got:
@@ -763,10 +763,10 @@ importers:
         specifier: workspace:^
         version: link:../errors
       archiver:
-        specifier: 8.0.0
+        specifier: ^8.0.0
         version: 8.0.0
       extract-zip:
-        specifier: 2.0.1
+        specifier: ^2.0.1
         version: 2.0.1(supports-color@8.1.1)
     devDependencies:
       folder-hash:

--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,11 @@
   "extends": ["github>tryghost/renovate-config"],
   "assignees": ["9larsons"],
   "ignoreDeps": ["moment-timezone"],
-  "packageRules": []
+  "packageRules": [
+    {
+      "description": "Runtime deps ship to npm, so keep them as caret ranges. Exact pins in every package force duplicate installs downstream (e.g. multiple lodash copies in Ghost core). Only bump the manifest when a release falls outside the existing range.",
+      "matchDepTypes": ["dependencies"],
+      "rangeStrategy": "replace"
+    }
+  ]
 }


### PR DESCRIPTION
## Context

Started from the question "does the release process respect `workspace:^`?" — it does. Published packages carry caret ranges, verified against npm:

```
@tryghost/api-framework@latest dependencies:
  "@tryghost/errors": "^3.3.12"
  "@tryghost/tpl":    "^2.3.12"
```

`nx release publish` packs via pnpm, which expands `workspace:^` to `^<version>`. A release dry-run confirms nx never rewrites those lines. Cross-package deps are not a duplicate source.

## The actual duplicate source

Every runtime dep that isn't a workspace package was exact-pinned — 58 entries across 29 packages, against exactly 2 range deps (`moment-timezone`, which is in `ignoreDeps`). `lodash` alone was pinned in 12 packages.

Those pins ship to npm. A consumer installing five `@tryghost/*` packages gets five exact `lodash` pins, and the moment renovate lands a bump in some packages before others, they get duplicate `lodash` trees. Same for `semver`, `json-stringify-safe`, `p-wait-for`, `form-data`. The external `@tryghost/nql@0.13.4` and `@tryghost/string@0.3.5` pins collide with Ghost core's own ranges the same way.

## Changes

1. **Caret all 58 exact runtime deps.** `devDependencies` stay pinned — they don't ship.
2. **Renovate rule**: `dependencies` use `rangeStrategy: "replace"` so update PRs keep ranges instead of re-pinning. Without this the inherited config re-pins everything on the next bump — as #957 did to `nodemailer` while this PR was open, which is what caused the rebase conflict here.

## Verification

- Resolved versions unchanged — the lockfile diff is 58 `specifier:` lines and zero `version:` lines
- `pnpm format:check`, `pnpm lint` clean
- `pnpm test:ci` — 43 projects pass

## Not included

An earlier revision of this PR also flipped `preserveMatchingDependencyRanges` to `true` in `nx.json`. Dropped — it is provably inert in this repo. Release output is byte-identical under both settings, in both flows:

| flow | `false` | `true` |
|---|---|---|
| `ship patch` (all projects) | 43 bumped | 43 bumped |
| `--projects=@tryghost/errors minor` | 19 bumped | 19 bumped |

The option only governs rewriting a **concrete** range like `^3.3.12` when the new version still satisfies it. Every cross-package dep here is `workspace:^`, which has no version text to preserve, so the option never has anything to act on. The live cascade knob is `updateDependents` (defaults to `"auto"`; setting it to `"never"` drops that second row from 19 to 1).

Worth noting `860315e3` replaced an explicit `updateDependents: "auto"` with `preserveMatchingDependencyRanges: false` — swapping the live knob for a dead one. Behavior didn't change only because `"auto"` is already the default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)