### PR TITLE
Release only the packages that changed

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,19 @@ Publishing is handled by `.github/workflows/publish.yml` after Nx release
 commits. Use the root `pnpm ship:*` scripts for versioning; they run the
 pre-ship test gate before creating release commits and tags.
 
+The ship scripts release only the packages that changed. `scripts/ship.mjs`
+compares each package against the git tag for its own current version and
+passes the changed set to `nx release version --projects=...`; dependents are
+pulled in by Nx's own `updateDependents: "auto"`. Run `pnpm ship:list` to see
+what a ship would release without touching anything, or set `SHIP_ALL=1` to
+force every package.
+
+Do not hand `nx release version <bump>` an explicit specifier without
+`--projects`. An explicit specifier disables change detection and bumps every
+package in scope. `nx affected` is not a substitute here either: Nx treats any
+`pnpm-lock.yaml` change as invalidating the whole graph, and renovate touches
+the lockfile on every dependency PR.
+
 ## Cleanup Boundaries
 
 Keep package-specific usage detail in the relevant package README. Add a root

--- a/package.json
+++ b/package.json
@@ -14,11 +14,12 @@
     "prepare": "husky",
     "test": "nx run-many -t test --parallel=10 --outputStyle=dynamic-legacy",
     "test:ci": "nx run-many -t test --outputStyle=static",
-    "lint": "oxlint -c .oxlintrc.json packages",
-    "format": "oxfmt -c .oxfmtrc.json \"packages/**/*.{js,ts,json,md}\"",
-    "format:check": "oxfmt -c .oxfmtrc.json --check \"packages/**/*.{js,ts,json,md}\"",
+    "lint": "oxlint -c .oxlintrc.json packages scripts",
+    "format": "oxfmt -c .oxfmtrc.json \"{packages,scripts}/**/*.{js,mjs,ts,json,md}\"",
+    "format:check": "oxfmt -c .oxfmtrc.json --check \"{packages,scripts}/**/*.{js,mjs,ts,json,md}\"",
     "preship": "git diff --quiet && git diff --cached --quiet || (echo 'Error: working tree must be clean before shipping' && exit 1) && pnpm test",
-    "ship": "nx release version --git-push --git-remote ${GHOST_UPSTREAM:-origin}",
+    "ship": "node scripts/ship.mjs",
+    "ship:list": "node scripts/ship.mjs --list",
     "ship:patch": "pnpm ship patch",
     "ship:minor": "pnpm ship minor",
     "ship:major": "pnpm ship major",
@@ -36,6 +37,6 @@
     "vitest": "4.1.11"
   },
   "lint-staged": {
-    "packages/**/*.{js,ts,json,md}": "oxfmt -c .oxfmtrc.json"
+    "{packages,scripts}/**/*.{js,mjs,ts,json,md}": "oxfmt -c .oxfmtrc.json"
   }
 }

--- a/scripts/ship.mjs
+++ b/scripts/ship.mjs
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+/**
+ * Version and tag only the packages that actually changed.
+ *
+ * `nx release version <bump>` applies the bump to every project in scope,
+ * unconditionally — handing it an explicit specifier disables change
+ * detection entirely. That published all 43 packages on every ship, even
+ * when two had changed.
+ *
+ * `nx affected` is not a substitute: nx treats any pnpm-lock.yaml change as
+ * invalidating the whole graph, and renovate touches the lockfile on every
+ * dependency PR, so the affected set is always all 43.
+ *
+ * Instead, compare each package against the git tag for its own current
+ * version. A package is released when its own files changed since it was
+ * last published, or when it has no tag yet. Dependents are pulled in by
+ * nx's own `updateDependents: "auto"`, so they are not computed here.
+ *
+ * Usage:
+ *   node scripts/ship.mjs patch          # version + tag changed packages
+ *   node scripts/ship.mjs --list         # print what would be released
+ *   SHIP_ALL=1 node scripts/ship.mjs patch   # force every package
+ */
+
+import { spawnSync } from 'node:child_process';
+import { readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+
+const tagExists = (tag) =>
+    spawnSync('git', ['rev-parse', '-q', '--verify', `refs/tags/${tag}`]).status === 0;
+
+const hasChangesSince = (tag, dir) =>
+    spawnSync('git', ['diff', '--quiet', tag, 'HEAD', '--', dir]).status !== 0;
+
+function releasablePackages() {
+    const released = [];
+    const skipped = [];
+
+    for (const entry of readdirSync('packages', { withFileTypes: true }).sort()) {
+        if (!entry.isDirectory()) continue;
+
+        const dir = join('packages', entry.name);
+        let pkg;
+        try {
+            pkg = JSON.parse(readFileSync(join(dir, 'package.json'), 'utf8'));
+        } catch {
+            continue;
+        }
+        if (pkg.private) continue;
+
+        const tag = `${pkg.name}@${pkg.version}`;
+        if (!tagExists(tag)) {
+            released.push({ name: pkg.name, reason: `no tag ${tag}` });
+        } else if (hasChangesSince(tag, dir)) {
+            released.push({ name: pkg.name, reason: `changed since ${tag}` });
+        } else {
+            skipped.push(pkg.name);
+        }
+    }
+
+    return { released, skipped };
+}
+
+function main() {
+    const args = process.argv.slice(2);
+    const listOnly = args.includes('--list');
+    const nxArgs = args.filter((a) => a !== '--list');
+
+    if (process.env.SHIP_ALL) {
+        console.log('SHIP_ALL set — releasing every package.');
+        if (listOnly) return;
+        return runNx(nxArgs, null);
+    }
+
+    const { released, skipped } = releasablePackages();
+
+    for (const { name, reason } of released) {
+        console.log(`release  ${name}  (${reason})`);
+    }
+    console.log(`\n${released.length} to release, ${skipped.length} unchanged.`);
+
+    if (released.length === 0) {
+        console.log('Nothing changed since the last release. Skipping.');
+        return;
+    }
+    if (listOnly) return;
+
+    runNx(nxArgs, released.map((p) => p.name).join(','));
+}
+
+function runNx(nxArgs, projects) {
+    const remote = process.env.GHOST_UPSTREAM || 'origin';
+    const argv = ['nx', 'release', 'version', ...nxArgs, '--git-push', '--git-remote', remote];
+    if (projects) argv.push(`--projects=${projects}`);
+
+    console.log(`\n> npx ${argv.join(' ')}\n`);
+    const result = spawnSync('npx', argv, { stdio: 'inherit' });
+    process.exit(result.status ?? 1);
+}
+
+main();


### PR DESCRIPTION
Stacked on #956 — review that one first. This PR's diff against its base is 3 files.

## The problem

Every ship publishes all 43 packages. Measured across the last three release commits — 43, 43, 43 package.json files each.

Between the two most recent releases, here's what actually changed:

| | |
|---|---|
| packages with any change since prior release | **2** (`job-manager`, `webhook-mock-receiver`) |
| packages bumped and published | **43** |

Both changed packages are leaves — nothing depends on either.

## Cause

`ship` runs `nx release version <bump>` against `projects: ["packages/*"]` with no filter. Handing nx an explicit bump specifier disables change detection entirely, so the bump applies to every project in scope unconditionally. Not renovate, and not nx dependency resolution.

## Why `nx affected` isn't the fix

The obvious move, tested against the last release:

```
nx show projects --affected --base=<last release> --head=main  →  43 projects
```

Nx treats any `pnpm-lock.yaml` change as invalidating the whole project graph. Renovate touches the lockfile on every dependency PR, so the affected set is always everything. Confirmed this is built-in nx behavior, not our `sharedGlobals` config — removing the lockfile entry from `sharedGlobals` still yields 43.

## Approach

`scripts/ship.mjs` compares each package against the git tag for its own current version (`@tryghost/errors@3.3.12`). A package is released when its own files changed since it was last published, or when it has no tag yet — which also covers `--first-release`. The changed set goes to `nx release version --projects=...`.

Per-package tags rather than a single "last release" commit, so a package skipped in one release is still picked up by the next.

Dependents are left to nx's own `updateDependents: "auto"` instead of being recomputed here.

Lockfile-only changes correctly select nothing: the lockfile isn't published, so a transitive bump that doesn't touch any `package.json` needs no republish.

## Result

Against `main`:

```
release  @tryghost/nodemailer            (changed since @tryghost/nodemailer@2.3.12)
release  @tryghost/request               (changed since @tryghost/request@4.0.5)
release  @tryghost/webhook-mock-receiver (changed since @tryghost/webhook-mock-receiver@2.3.12)

3 to release, 40 unchanged.
```

Exactly the packages #955 and #957 touched. Nx expands that to 9 with dependents, versus 43 today.

## Also

- `pnpm ship:list` previews a release without touching anything
- `SHIP_ALL=1` forces every package, for when you do want a full republish
- Root `lint` and `format` globs extended to cover `scripts/`, which they previously missed (`packages/**` only)

## Verification

- On `main`: 3 packages. On this branch: 29 — matching the 29 package.json files #956 edits
- At the last release commit `a954c386`: `0 to release, 43 unchanged` → skips cleanly without invoking nx
- `nx release version patch --projects=<the 3> --dry-run` → 9 packages (3 + 6 dependents)
- `pnpm lint`, `pnpm format:check` clean (348 files, up from 347)
- `pnpm test:ci` — 43 projects pass

I did not execute a real (non-dry-run) ship, since that pushes tags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)