### PR TITLE
🐛 Fixed order attribute pattern matching

### DIFF
--- a/packages/bookshelf-order/lib/bookshelf-order.js
+++ b/packages/bookshelf-order/lib/bookshelf-order.js
@@ -53,12 +53,12 @@ const orderPlugin = function orderPlugin(Bookshelf) {
                     return;
                 }
 
-                const matchingOrderAttribute = orderAttributes.find((orderAttribute) => {
+                const matchingOrderAttribute = orderAttributes.find((attribute) => {
                     // NOTE: this logic assumes we use different field names for "parent" and "child" relations.
                     //       E.g.: ['parent.title', 'child.title'] and ['child.title', 'parent.title'] - would not
                     //       distinguish on which relation to sort neither which order to pick the fields on.
                     //       For more context see: https://github.com/TryGhost/Ghost/pull/12226#discussion_r493085098
-                    return orderAttribute.endsWith(field);
+                    return attribute === field || attribute.endsWith(`.${field}`);
                 });
 
                 if (!matchingOrderAttribute) {


### PR DESCRIPTION
no ref
- match exactly or by exact field name, rather than a generic suffix match which is less precise