### PR TITLE
Added batch shipping to the metrics package

### DIFF
--- a/packages/elasticsearch/lib/ElasticSearch.js
+++ b/packages/elasticsearch/lib/ElasticSearch.js
@@ -37,6 +37,52 @@ class ElasticSearch {
             debug('Failed to ship log', error.message);
         }
     }
+
+    /**
+     * Write a batch of events to ElasticSearch in a single bulk request
+     *
+     * Uses the `create` action rather than `index` so the same call works
+     * against data streams as well as regular indices; without an `_id` the
+     * two are equivalent for append-only writes.
+     * @param {Array<{index: string, document: Object}>} operations Events to index, each with its target index
+     * @returns {Promise<void>}
+     */
+    async bulk(operations) {
+        if (!Array.isArray(operations) || operations.length === 0) {
+            return;
+        }
+
+        const body = [];
+
+        for (const operation of operations) {
+            if (typeof operation?.document !== 'object' || operation.document === null) {
+                debug('ElasticSearch transport requires log data to be an object');
+                continue;
+            }
+
+            body.push({ create: { _index: operation.index } });
+            body.push(operation.document);
+        }
+
+        if (body.length === 0) {
+            return;
+        }
+
+        try {
+            const result = await this.client.bulk({ operations: body });
+
+            // Partial failures don't reject, so they'd otherwise be invisible
+            if (result?.errors) {
+                const failed = result.items.filter((item) => item.create?.error);
+                debug(
+                    `Failed to ship ${failed.length} of ${result.items.length} logs`,
+                    failed[0]?.create?.error?.reason,
+                );
+            }
+        } catch (error) {
+            debug('Failed to ship logs', error.message);
+        }
+    }
 }
 
 module.exports = ElasticSearch;

--- a/packages/elasticsearch/lib/ElasticSearch.js
+++ b/packages/elasticsearch/lib/ElasticSearch.js
@@ -1,6 +1,10 @@
 const { Client } = require('@elastic/elasticsearch');
 const debug = require('@tryghost/debug')('logging:elasticsearch');
 
+// Elasticsearch defaults http.max_content_length to 100 MB. Keep every bulk
+// request strictly below that limit, including the newline after each NDJSON line.
+const MAX_BULK_REQUEST_BYTES = 100 * 1024 * 1024;
+
 // Singleton client - multiple children made from it for a single connection pool
 let client;
 
@@ -53,6 +57,30 @@ class ElasticSearch {
         }
 
         const body = [];
+        let bodyBytes = 0;
+
+        const ship = async () => {
+            if (body.length === 0) {
+                return;
+            }
+
+            try {
+                const result = await this.client.bulk({ operations: body.splice(0) });
+
+                // Partial failures don't reject, so they'd otherwise be invisible
+                if (result?.errors) {
+                    const failed = result.items.filter((item) => item.create?.error);
+                    debug(
+                        `Failed to ship ${failed.length} of ${result.items.length} logs`,
+                        failed[0]?.create?.error?.reason,
+                    );
+                }
+            } catch (error) {
+                debug('Failed to ship logs', error.message);
+            }
+
+            bodyBytes = 0;
+        };
 
         for (const operation of operations) {
             if (typeof operation?.document !== 'object' || operation.document === null) {
@@ -60,28 +88,33 @@ class ElasticSearch {
                 continue;
             }
 
-            body.push({ create: { _index: operation.index } });
-            body.push(operation.document);
-        }
+            const action = { create: { _index: operation.index } };
+            let operationBytes;
 
-        if (body.length === 0) {
-            return;
-        }
-
-        try {
-            const result = await this.client.bulk({ operations: body });
-
-            // Partial failures don't reject, so they'd otherwise be invisible
-            if (result?.errors) {
-                const failed = result.items.filter((item) => item.create?.error);
-                debug(
-                    `Failed to ship ${failed.length} of ${result.items.length} logs`,
-                    failed[0]?.create?.error?.reason,
-                );
+            try {
+                operationBytes =
+                    Buffer.byteLength(JSON.stringify(action)) +
+                    Buffer.byteLength(JSON.stringify(operation.document)) +
+                    2;
+            } catch (error) {
+                debug('Failed to serialize log for bulk shipping', error.message);
+                continue;
             }
-        } catch (error) {
-            debug('Failed to ship logs', error.message);
+
+            if (operationBytes >= MAX_BULK_REQUEST_BYTES) {
+                debug('Log is too large for Elasticsearch bulk shipping');
+                continue;
+            }
+
+            if (bodyBytes + operationBytes >= MAX_BULK_REQUEST_BYTES) {
+                await ship();
+            }
+
+            body.push(action, operation.document);
+            bodyBytes += operationBytes;
         }
+
+        await ship();
     }
 }
 

--- a/packages/elasticsearch/test/ElasticSearch.test.js
+++ b/packages/elasticsearch/test/ElasticSearch.test.js
@@ -115,6 +115,78 @@ describe('ElasticSearch', function () {
             await es.index({ message: 'Test data' }, indexConfig);
         });
     });
+
+    it('Ships a batch of events in a single bulk request', async function () {
+        const es = new ElasticSearch(testClientConfig);
+        const bulkStub = sandbox.stub(Client.prototype, 'bulk').resolves({ errors: false });
+
+        await es.bulk([
+            { index: 'metrics-cache-hit', document: { value: 1 } },
+            { index: 'metrics-cache-miss', document: { value: 2 } },
+        ]);
+
+        assert.equal(bulkStub.callCount, 1);
+        assert.deepEqual(bulkStub.firstCall.args[0].operations, [
+            { create: { _index: 'metrics-cache-hit' } },
+            { value: 1 },
+            { create: { _index: 'metrics-cache-miss' } },
+            { value: 2 },
+        ]);
+    });
+
+    it('Does not send a bulk request for an empty or invalid batch', async function () {
+        const es = new ElasticSearch(testClientConfig);
+        const bulkStub = sandbox.stub(Client.prototype, 'bulk');
+
+        await es.bulk([]);
+        await es.bulk(undefined);
+        await es.bulk([
+            { index: 'metrics-test', document: 'not an object' },
+            { index: 'metrics-test', document: null },
+        ]);
+
+        assert.equal(bulkStub.callCount, 0);
+    });
+
+    it('Skips invalid documents but ships the rest of the batch', async function () {
+        const es = new ElasticSearch(testClientConfig);
+        const bulkStub = sandbox.stub(Client.prototype, 'bulk').resolves({ errors: false });
+
+        await es.bulk([
+            { index: 'metrics-test', document: 'not an object' },
+            { index: 'metrics-test', document: { value: 1 } },
+        ]);
+
+        assert.equal(bulkStub.callCount, 1);
+        assert.deepEqual(bulkStub.firstCall.args[0].operations, [
+            { create: { _index: 'metrics-test' } },
+            { value: 1 },
+        ]);
+    });
+
+    it('Catches bulk failures without throwing', async function () {
+        const es = new ElasticSearch(testClientConfig);
+        sandbox.stub(Client.prototype, 'bulk').rejects(new Error('boom'));
+
+        await assert.doesNotReject(async () => {
+            await es.bulk([{ index: 'metrics-test', document: { value: 1 } }]);
+        });
+    });
+
+    it('Does not throw on partial bulk failures', async function () {
+        const es = new ElasticSearch(testClientConfig);
+        sandbox.stub(Client.prototype, 'bulk').resolves({
+            errors: true,
+            items: [{ create: { error: { reason: 'mapper_parsing_exception' } } }, { create: {} }],
+        });
+
+        await assert.doesNotReject(async () => {
+            await es.bulk([
+                { index: 'metrics-test', document: { value: 'a' } },
+                { index: 'metrics-test', document: { value: 1 } },
+            ]);
+        });
+    });
 });
 
 describe('ElasticSearch Bunyan', function () {

--- a/packages/elasticsearch/test/ElasticSearch.test.js
+++ b/packages/elasticsearch/test/ElasticSearch.test.js
@@ -164,6 +164,60 @@ describe('ElasticSearch', function () {
         ]);
     });
 
+    it('Splits bulk requests by serialized size and skips oversized documents', async function () {
+        const es = new ElasticSearch(testClientConfig);
+        const bulkStub = sandbox.stub(Client.prototype, 'bulk').resolves({ errors: false });
+        const originalByteLength = Buffer.byteLength;
+
+        sandbox.stub(Buffer, 'byteLength').callsFake((value) => {
+            if (value.includes('"size":"large"')) {
+                return 60 * 1024 * 1024;
+            }
+
+            if (value.includes('"size":"oversized"')) {
+                return 100 * 1024 * 1024;
+            }
+
+            return originalByteLength(value);
+        });
+
+        await es.bulk([
+            { index: 'metrics-test', document: { size: 'large', value: 1 } },
+            { index: 'metrics-test', document: { size: 'large', value: 2 } },
+            { index: 'metrics-test', document: { size: 'oversized' } },
+            { index: 'metrics-test', document: { value: 3 } },
+        ]);
+
+        assert.equal(bulkStub.callCount, 2);
+        assert.deepEqual(
+            bulkStub.firstCall.args[0].operations.filter((_, index) => index % 2 === 1),
+            [{ size: 'large', value: 1 }],
+        );
+        assert.deepEqual(
+            bulkStub.secondCall.args[0].operations.filter((_, index) => index % 2 === 1),
+            [{ size: 'large', value: 2 }, { value: 3 }],
+        );
+    });
+
+    it('Skips an unserializable bulk document without dropping its neighbours', async function () {
+        const es = new ElasticSearch(testClientConfig);
+        const bulkStub = sandbox.stub(Client.prototype, 'bulk').resolves({ errors: false });
+        const circular = {};
+        circular.self = circular;
+
+        await es.bulk([
+            { index: 'metrics-test', document: { value: 1 } },
+            { index: 'metrics-test', document: circular },
+            { index: 'metrics-test', document: { value: 2 } },
+        ]);
+
+        assert.equal(bulkStub.callCount, 1);
+        assert.deepEqual(
+            bulkStub.firstCall.args[0].operations.filter((_, index) => index % 2 === 1),
+            [{ value: 1 }, { value: 2 }],
+        );
+    });
+
     it('Catches bulk failures without throwing', async function () {
         const es = new ElasticSearch(testClientConfig);
         sandbox.stub(Client.prototype, 'bulk').rejects(new Error('boom'));

--- a/packages/metrics/README.md
+++ b/packages/metrics/README.md
@@ -65,6 +65,75 @@ An invalid configured rate throws when the instance is constructed. An invalid
 per-call rate is ignored in favour of the configured rate, so a bad call site
 cannot break the code path it is measuring.
 
+### Batching
+
+Sampling reduces how many metrics are shipped; batching reduces how many
+requests they take. With batching on, the Elasticsearch transport buffers
+documents and ships them with the bulk API, so a hot code path costs one
+request per batch instead of one per metric. It is off by default:
+
+```js
+const metrics = require('@tryghost/metrics');
+
+const batched = new metrics.GhostMetrics({
+    metrics: {
+        transports: ['elasticsearch'],
+        batch: true,
+    },
+});
+```
+
+`batch: true` uses the defaults; pass an object to override them:
+
+| Option          | Default     | Meaning                                                         |
+| --------------- | ----------- | --------------------------------------------------------------- |
+| `enabled`       | `true`      | Set to `false` to turn batching off without dropping the config |
+| `size`          | `100`       | Buffered documents that trigger a bulk request                  |
+| `maxWaitMs`     | `5000`      | How long a document may sit in the buffer before it is shipped  |
+| `maxBufferSize` | `size * 10` | Hard cap on buffered documents; further metrics are dropped     |
+
+```js
+const batched = new metrics.GhostMetrics({
+    metrics: {
+        transports: ['elasticsearch'],
+        batch: {
+            size: 500,
+            maxWaitMs: 2000,
+        },
+    },
+});
+```
+
+Documents for different metric names can share a batch, because each bulk
+operation carries its own index. Sampling still applies first, so only metrics
+that survive their sample rate are buffered.
+
+Batching changes two things worth knowing about:
+
+- `metric()` resolves once the metric is **buffered**, not once it has been
+  shipped. It was already fire-and-forget for most callers, but a caller that
+  awaited delivery no longer gets it.
+- Buffered metrics are lost if the process exits without draining them. Call
+  `flush()` from your shutdown handler; it is a no-op when batching is off, so
+  it is always safe to call.
+
+```js
+process.on('SIGTERM', async () => {
+    await batched.flush();
+    process.exit(0);
+});
+```
+
+The buffer is bounded: once it holds `maxBufferSize` documents, further metrics
+are dropped rather than growing the heap while Elasticsearch is slow or down.
+Only one bulk request is ever in flight, and a failed batch is dropped without
+rejecting, so a metric call can never break the code path it is measuring.
+
+Invalid batch config throws when the instance is constructed.
+
+The stdout transport is unaffected - it writes locally, so there is nothing to
+batch.
+
 ### Types
 
 Types ship with the package. `GhostMetrics` is exported as both a value (the
@@ -77,6 +146,7 @@ import type {
     GhostMetricsOptions,
     MetricsOptions,
     MetricOptions,
+    BatchOptions,
     ElasticsearchOptions,
     MetricShipper,
 } from '@tryghost/metrics';

--- a/packages/metrics/lib/GhostMetrics.d.ts
+++ b/packages/metrics/lib/GhostMetrics.d.ts
@@ -1,3 +1,5 @@
+import MetricsBatch = require('./MetricsBatch');
+
 /**
  * Elasticsearch transport configuration.
  */
@@ -10,6 +12,29 @@ interface ElasticsearchOptions {
     password?: string;
     /** Optional proxy URL; when absent no proxy is used. */
     proxy?: string;
+}
+
+/**
+ * Batch shipping configuration for network transports.
+ */
+interface BatchOptions {
+    /** Set to `false` to turn batching off while keeping the rest of the config. @default true */
+    enabled?: boolean;
+    /** Buffered documents that trigger a bulk request. @default 100 */
+    size?: number;
+    /** How long a document may sit in the buffer before it is shipped, in milliseconds. @default 5000 */
+    maxWaitMs?: number;
+    /** Hard cap on buffered documents; further metrics are dropped. @default `size * 10` */
+    maxBufferSize?: number;
+}
+
+/**
+ * Resolved batch configuration, with every value filled in.
+ */
+interface ResolvedBatchOptions {
+    size: number;
+    maxWaitMs: number;
+    maxBufferSize: number;
 }
 
 /**
@@ -27,6 +52,12 @@ interface MetricsOptions {
     sampleRate?: number;
     /** Per-metric sample rate overrides, keyed by metric name. Same validation as `sampleRate`. */
     sampleRates?: Record<string, number>;
+    /**
+     * Ship metrics in batches rather than one request per metric. `true` uses the defaults,
+     * an object overrides them, absent or `false` keeps one request per metric. Throws at
+     * construction time for values that aren't positive whole numbers.
+     */
+    batch?: boolean | BatchOptions;
 }
 
 /**
@@ -71,7 +102,11 @@ declare class GhostMetrics {
     metadata: Record<string, unknown>;
     sampleRate: number;
     sampleRates: Record<string, number>;
+    /** Resolved batch config, or `null` when batching is off. */
+    batch: ResolvedBatchOptions | null;
     shippers: Record<string, MetricShipper>;
+    /** Buffers belonging to batching transports, drained by {@link GhostMetrics.flush}. */
+    batches: MetricsBatch[];
 
     constructor(options?: GhostMetricsOptions);
 
@@ -82,9 +117,15 @@ declare class GhostMetrics {
 
     /**
      * Setup ElasticSearch metric shipper. Metrics are shipped to a per-metric
-     * index named `metrics-<name>`; the metric name should be sluggified.
+     * index named `metrics-<name>`; the metric name should be sluggified. With
+     * batching on, documents are buffered and shipped with the bulk API.
      */
     setupElasticsearchShipper(): void;
+
+    /**
+     * Ship anything buffered by batching transports. A no-op when batching is off.
+     */
+    flush(): Promise<void>;
 
     /**
      * Resolve the sample rate for a metric: per-call override, then per-metric config,
@@ -94,6 +135,8 @@ declare class GhostMetrics {
 
     /**
      * Ship a metric through every configured transport, unless it is dropped by sampling.
+     * With batching on, the returned promise resolves once the metric is buffered rather
+     * than once it has been shipped.
      * @param name Metric name, should be slugified for back-end compatibility (e.g. `"memory-usage"`).
      * @param value Metric value; coerced to an object before being shipped.
      * @param options Per-call options, e.g. a `sampleRate` override.
@@ -106,6 +149,8 @@ declare namespace GhostMetrics {
         ElasticsearchOptions,
         MetricsOptions,
         MetricOptions,
+        BatchOptions,
+        ResolvedBatchOptions,
         GhostMetricsOptions,
         MetricShipper,
     };

--- a/packages/metrics/lib/GhostMetrics.js
+++ b/packages/metrics/lib/GhostMetrics.js
@@ -1,4 +1,10 @@
 const jsonStringifySafe = require('json-stringify-safe');
+const MetricsBatch = require('./MetricsBatch');
+
+const DEFAULT_BATCH_SIZE = 100;
+const DEFAULT_BATCH_MAX_WAIT_MS = 5000;
+// Ten batches' worth of headroom before the buffer starts shedding load
+const DEFAULT_BATCH_BUFFER_FACTOR = 10;
 
 /**
  * @description Check a value is usable as a sample rate: a number between 0 and 1 inclusive
@@ -28,6 +34,126 @@ function normalizeSampleRate(rate, key) {
 }
 
 /**
+ * @description Validate a batching config value that must be a positive whole number
+ * @param {any} value Candidate value
+ * @param {number} fallback Value to use when unset
+ * @param {string} key Config key used in the error message
+ * @returns {number}
+ */
+function normalizePositiveInteger(value, fallback, key) {
+    if (value === undefined || value === null) {
+        return fallback;
+    }
+
+    if (typeof value !== 'number' || !Number.isSafeInteger(value) || value < 1) {
+        throw new Error(`${key} must be a positive whole number, got ${jsonStringifySafe(value)}`);
+    }
+
+    return value;
+}
+
+/**
+ * @description Validate the batching config, returning null when batching is off
+ * @param {any} batch Candidate batch config: absent/false for off, true or a property bag for on
+ * @returns {{size: number, maxWaitMs: number, maxBufferSize: number} | null}
+ */
+function normalizeBatch(batch) {
+    if (batch === undefined || batch === null || batch === false) {
+        return null;
+    }
+
+    if (batch === true) {
+        batch = {};
+    }
+
+    if (typeof batch !== 'object' || Array.isArray(batch)) {
+        throw new Error(
+            `metrics.batch must be a boolean or an object, got ${jsonStringifySafe(batch)}`,
+        );
+    }
+
+    // `enabled` lets a deployment turn batching off without discarding the rest
+    // of the config, which matters when it is layered from config files
+    if (batch.enabled === false) {
+        return null;
+    }
+
+    const size = normalizePositiveInteger(batch.size, DEFAULT_BATCH_SIZE, 'metrics.batch.size');
+    const maxWaitMs = normalizePositiveInteger(
+        batch.maxWaitMs,
+        DEFAULT_BATCH_MAX_WAIT_MS,
+        'metrics.batch.maxWaitMs',
+    );
+    const maxBufferSize = normalizePositiveInteger(
+        batch.maxBufferSize,
+        size * DEFAULT_BATCH_BUFFER_FACTOR,
+        'metrics.batch.maxBufferSize',
+    );
+
+    if (maxBufferSize < size) {
+        throw new Error(
+            `metrics.batch.maxBufferSize must be at least metrics.batch.size (${size}), got ${maxBufferSize}`,
+        );
+    }
+
+    return { size, maxWaitMs, maxBufferSize };
+}
+
+/**
+ * @description Clone structured metric data without allowing unusual values
+ * to make instrumentation throw.
+ * @param {any} value Value to clone
+ * @returns {any}
+ */
+function cloneMetricValue(value) {
+    if (typeof value !== 'object' || value === null) {
+        return value;
+    }
+
+    try {
+        return structuredClone(value);
+    } catch {
+        // Keep instrumentation from throwing for unusual non-cloneable values.
+        return Array.isArray(value) ? [...value] : { ...value };
+    }
+}
+
+/**
+ * @description Build the document shipped for a metric value
+ * The value is copied rather than mutated, so a batched document can't be
+ * changed by the caller after it has been buffered.
+ * @param {any} value Value of the metric
+ * @param {object} metadata Metadata to ship alongside the value
+ * @param {number} sampleRate Rate the metric survived
+ * @returns {object}
+ */
+function buildDocument(value, metadata, sampleRate) {
+    // Metrics are expected to be structured data. Clone them synchronously so
+    // callers can safely reuse or mutate nested values after `metric()` returns.
+    const clonedValue = cloneMetricValue(value);
+    const document =
+        typeof clonedValue === 'object' && clonedValue !== null && !Array.isArray(clonedValue)
+            ? clonedValue
+            : { value: clonedValue };
+
+    if (!('@timestamp' in document)) {
+        document['@timestamp'] = Date.now();
+    }
+
+    if (metadata) {
+        document.metadata = cloneMetricValue(metadata);
+    }
+
+    // Sampled documents carry their rate so consumers can scale counts back up.
+    // An absent sampleRate means the metric was not sampled (i.e. a rate of 1).
+    if (sampleRate < 1) {
+        document.sampleRate = sampleRate;
+    }
+
+    return document;
+}
+
+/**
  * @description Metric shipper class built on the loggingrc config used in Ghost projects
  */
 class GhostMetrics {
@@ -40,6 +166,7 @@ class GhostMetrics {
      * metrics.metadata:    A property bag of metadata values to be shipped alongside the metric value
      * metrics.sampleRate:  Default proportion of metrics to ship, between 0 and 1 (defaults to 1, ship everything)
      * metrics.sampleRates: Per-metric sample rate overrides, keyed by metric name
+     * metrics.batch:       Batch shipping config for network transports; absent or false to ship one metric per request
      * elasticsearch:       Elasticsearch transport configuration
      * @param {object} options Bag of options
      */
@@ -56,6 +183,7 @@ class GhostMetrics {
             this.transports = options.metrics.transports || [];
             this.metadata = options.metrics.metadata || {};
             this.sampleRate = normalizeSampleRate(options.metrics.sampleRate, 'metrics.sampleRate');
+            this.batch = normalizeBatch(options.metrics.batch);
 
             for (const [name, rate] of Object.entries(options.metrics.sampleRates || {})) {
                 this.sampleRates[name] = normalizeSampleRate(rate, `metrics.sampleRates.${name}`);
@@ -64,6 +192,7 @@ class GhostMetrics {
             this.transports = [];
             this.metadata = {};
             this.sampleRate = 1;
+            this.batch = null;
         }
 
         // CASE: special env variable to enable long mode and level info
@@ -72,6 +201,8 @@ class GhostMetrics {
         }
 
         this.shippers = {};
+        // Populated by transports that buffer, so `flush()` can drain them
+        this.batches = [];
 
         this.transports.forEach((transport) => {
             let transportFn = `setup${transport[0].toUpperCase()}${transport.substr(1)}Shipper`;
@@ -126,27 +257,47 @@ class GhostMetrics {
             proxy: 'proxy' in this.elasticsearch ? this.elasticsearch.proxy : null,
         });
 
+        if (!this.batch) {
+            this.shippers.elasticsearch = (name, value, sampleRate) => {
+                return elasticSearch.index(
+                    buildDocument(value, this.metadata, sampleRate),
+                    `metrics-${name}`,
+                );
+            };
+
+            return;
+        }
+
+        // Batched metrics are shipped with the bulk API, so a hot code path
+        // costs one request per batch instead of one per metric. Documents for
+        // different metric names can share a batch because each operation
+        // carries its own index.
+        const batch = new MetricsBatch({
+            ...this.batch,
+            ship: (operations) => elasticSearch.bulk(operations),
+        });
+
+        this.batches.push(batch);
+
         this.shippers.elasticsearch = (name, value, sampleRate) => {
-            if (typeof value !== 'object') {
-                value = { value };
-            }
+            batch.add({
+                index: `metrics-${name}`,
+                document: buildDocument(value, this.metadata, sampleRate),
+            });
 
-            if (!('@timestamp' in value)) {
-                value['@timestamp'] = Date.now();
-            }
-
-            if (this.metadata) {
-                value.metadata = this.metadata;
-            }
-
-            // Sampled documents carry their rate so consumers can scale counts back up.
-            // An absent sampleRate means the metric was not sampled (i.e. a rate of 1).
-            if (sampleRate < 1) {
-                value.sampleRate = sampleRate;
-            }
-
-            return elasticSearch.index(value, `metrics-${name}`);
+            // Resolves once the metric is buffered, not once it is shipped
+            return Promise.resolve();
         };
+    }
+
+    /**
+     * @description Ship anything buffered by batching transports
+     * A no-op when batching is off, so callers (e.g. a shutdown handler) can
+     * always call it without knowing how the instance is configured.
+     * @returns {Promise<void>}
+     */
+    async flush() {
+        await Promise.allSettled(this.batches.map((batch) => batch.flush()));
     }
 
     /**

--- a/packages/metrics/lib/GhostMetrics.js
+++ b/packages/metrics/lib/GhostMetrics.js
@@ -74,6 +74,12 @@ function normalizeBatch(batch) {
 
     // `enabled` lets a deployment turn batching off without discarding the rest
     // of the config, which matters when it is layered from config files
+    if ('enabled' in batch && typeof batch.enabled !== 'boolean') {
+        throw new Error(
+            `metrics.batch.enabled must be a boolean, got ${jsonStringifySafe(batch.enabled)}`,
+        );
+    }
+
     if (batch.enabled === false) {
         return null;
     }
@@ -105,6 +111,30 @@ function normalizeBatch(batch) {
  * @param {any} value Value to clone
  * @returns {any}
  */
+function cloneMetricValueFallback(value, seen = new WeakMap()) {
+    if (typeof value !== 'object' || value === null) {
+        return value;
+    }
+
+    if (seen.has(value)) {
+        return seen.get(value);
+    }
+
+    const prototype = Object.getPrototypeOf(value);
+    if (!Array.isArray(value) && prototype !== Object.prototype && prototype !== null) {
+        return value;
+    }
+
+    const clone = Array.isArray(value) ? [] : Object.create(prototype);
+    seen.set(value, clone);
+
+    for (const [key, nestedValue] of Object.entries(value)) {
+        clone[key] = cloneMetricValueFallback(nestedValue, seen);
+    }
+
+    return clone;
+}
+
 function cloneMetricValue(value) {
     if (typeof value !== 'object' || value === null) {
         return value;
@@ -114,7 +144,7 @@ function cloneMetricValue(value) {
         return structuredClone(value);
     } catch {
         // Keep instrumentation from throwing for unusual non-cloneable values.
-        return Array.isArray(value) ? [...value] : { ...value };
+        return cloneMetricValueFallback(value);
     }
 }
 

--- a/packages/metrics/lib/MetricsBatch.d.ts
+++ b/packages/metrics/lib/MetricsBatch.d.ts
@@ -1,0 +1,49 @@
+/**
+ * Buffers shipping operations and hands them off in batches.
+ *
+ * Batching trades delivery latency for a much smaller number of requests.
+ * Buffered operations are handed off when the buffer reaches `size`, when
+ * `maxWaitMs` has elapsed since the first buffered operation, or when
+ * {@link MetricsBatch.flush} is called.
+ */
+declare class MetricsBatch<T = unknown> {
+    /** Number of buffered operations that triggers a hand-off. */
+    size: number;
+    /** How long an operation may sit in the buffer before it is handed off, in milliseconds. */
+    maxWaitMs: number;
+    /** Hard cap on buffered operations; further operations are dropped. */
+    maxBufferSize: number;
+    /** Hands a batch of operations to the transport. */
+    ship: (operations: T[]) => Promise<unknown>;
+    /** Operations waiting to be shipped. */
+    buffer: T[];
+    /** Count of operations dropped because the buffer was full. */
+    dropped: number;
+
+    constructor(options: {
+        size: number;
+        maxWaitMs: number;
+        maxBufferSize: number;
+        ship: (operations: T[]) => Promise<unknown>;
+    });
+
+    /**
+     * Buffer an operation, handing the buffer off if it is now full. Operations
+     * arriving once the buffer is at `maxBufferSize` are dropped.
+     */
+    add(operation: T): void;
+
+    /** Start the max-wait timer, unless one is already running. */
+    startTimer(): void;
+
+    /**
+     * Ship everything buffered right now, waiting behind any in-flight batch.
+     * Never rejects.
+     */
+    flush(): Promise<void>;
+
+    /** Hand the whole buffer to the transport. Never rejects. */
+    drain(): Promise<void>;
+}
+
+export = MetricsBatch;

--- a/packages/metrics/lib/MetricsBatch.js
+++ b/packages/metrics/lib/MetricsBatch.js
@@ -1,0 +1,117 @@
+/**
+ * @description Buffers shipping operations and hands them off in batches
+ *
+ * Batching trades delivery latency for a much smaller number of requests: the
+ * caller gets one round-trip per batch instead of one per metric. Buffered
+ * operations are handed off when the buffer reaches `size`, when `maxWaitMs`
+ * has elapsed since the first buffered operation, or when `flush()` is called.
+ */
+class MetricsBatch {
+    /**
+     * @param {object} options Bag of options
+     * @param {number} options.size Number of buffered operations that triggers a hand-off
+     * @param {number} options.maxWaitMs How long an operation may sit in the buffer before it is handed off
+     * @param {number} options.maxBufferSize Hard cap on buffered operations; further operations are dropped
+     * @param {(operations: any[]) => Promise<any>} options.ship Hands a batch of operations to the transport
+     */
+    constructor({ size, maxWaitMs, maxBufferSize, ship }) {
+        this.size = size;
+        this.maxWaitMs = maxWaitMs;
+        this.maxBufferSize = maxBufferSize;
+        this.ship = ship;
+
+        this.buffer = [];
+        this.timer = null;
+        // Serialises hand-offs, so only one batch is ever in flight
+        this.pending = Promise.resolve();
+        // A non-zero count means the transport couldn't keep up and metrics
+        // were lost; read it off the instance when metrics go missing
+        this.dropped = 0;
+    }
+
+    /**
+     * @description Buffer an operation, handing the buffer off if it is now full
+     * @param {any} operation Operation to ship
+     */
+    add(operation) {
+        if (this.buffer.length >= this.maxBufferSize) {
+            // Shed load rather than growing without bound when the transport is
+            // slow or down: losing metrics beats exhausting the heap
+            this.dropped += 1;
+            return;
+        }
+
+        this.buffer.push(operation);
+
+        // Queue exactly once when the buffer crosses the threshold. `drain()`
+        // resets the buffer before awaiting the transport, so the next buffer
+        // can independently cross the threshold and line up behind it.
+        if (this.buffer.length === this.size) {
+            this.flush();
+            return;
+        }
+
+        this.startTimer();
+    }
+
+    /**
+     * @description Start the max-wait timer, unless one is already running
+     * The timer is unreferenced so a partially full buffer can never hold the
+     * event loop - and therefore the process - open.
+     */
+    startTimer() {
+        if (this.timer) {
+            return;
+        }
+
+        this.timer = setTimeout(() => {
+            this.timer = null;
+            this.flush();
+        }, this.maxWaitMs);
+
+        this.timer.unref?.();
+    }
+
+    /**
+     * @description Ship everything buffered right now
+     * Waits behind any in-flight batch, so batches reach the transport in
+     * order and only one request is open at a time.
+     * @returns {Promise<void>}
+     */
+    flush() {
+        if (this.timer) {
+            clearTimeout(this.timer);
+            this.timer = null;
+        }
+
+        const previous = this.pending;
+
+        this.pending = previous.then(() => this.drain());
+
+        return this.pending;
+    }
+
+    /**
+     * @description Hand the whole buffer to the transport
+     * Never rejects, so a failed batch can't poison the hand-off chain or the
+     * code path being measured. Transports report their own failures - the
+     * Elasticsearch one logs them under the `logging:elasticsearch` debug namespace.
+     * @returns {Promise<void>}
+     */
+    async drain() {
+        if (this.buffer.length === 0) {
+            return;
+        }
+
+        const operations = this.buffer;
+        this.buffer = [];
+
+        try {
+            await this.ship(operations);
+        } catch {
+            // Swallowed: a metric call can never break the path it measures
+        }
+    }
+}
+
+module.exports = MetricsBatch;

--- a/packages/metrics/lib/metrics.d.ts
+++ b/packages/metrics/lib/metrics.d.ts
@@ -17,6 +17,8 @@ declare namespace metrics {
     export type ElasticsearchOptions = GhostMetricsClass.ElasticsearchOptions;
     export type MetricsOptions = GhostMetricsClass.MetricsOptions;
     export type MetricOptions = GhostMetricsClass.MetricOptions;
+    export type BatchOptions = GhostMetricsClass.BatchOptions;
+    export type ResolvedBatchOptions = GhostMetricsClass.ResolvedBatchOptions;
     export type GhostMetricsOptions = GhostMetricsClass.GhostMetricsOptions;
     export type MetricShipper = GhostMetricsClass.MetricShipper;
 }

--- a/packages/metrics/test/metrics.test.js
+++ b/packages/metrics/test/metrics.test.js
@@ -481,6 +481,10 @@ describe('Batching', function () {
     it('throws for invalid batch config', function () {
         assert.throws(() => batchedMetrics('yes'), /metrics\.batch must be a boolean or an object/);
         assert.throws(() => batchedMetrics([1]), /metrics\.batch must be a boolean or an object/);
+        assert.throws(
+            () => batchedMetrics({ enabled: 'false' }),
+            /metrics\.batch\.enabled must be a boolean/,
+        );
 
         for (const size of ['10', 0, -1, 1.5, NaN]) {
             assert.throws(
@@ -749,12 +753,30 @@ describe('Batching', function () {
     it('does not throw when a metric value cannot be deeply cloned', async function () {
         const ghostMetrics = batchedMetrics({ size: 1 });
         const bulk = sandbox.stub(ElasticSearch.prototype, 'bulk').resolves();
-        const value = { callback: () => 'not cloneable' };
+        const callback = () => 'not cloneable';
+        const leaf = new WeakMap();
+        const nullPrototype = Object.assign(Object.create(null), { state: 'before' });
+        const value = {
+            nested: { callback, state: 'before' },
+            list: [{ state: 'before' }],
+            nullPrototype,
+            leaf,
+        };
+        value.self = value;
 
         await assert.doesNotReject(() => ghostMetrics.metric('callback-metric', value));
+        value.nested.state = 'after';
+        value.list[0].state = 'after';
+        nullPrototype.state = 'after';
         await ghostMetrics.flush();
 
-        assert.equal(bulk.firstCall.args[0][0].document.callback, value.callback);
+        const document = bulk.firstCall.args[0][0].document;
+        assert.equal(document.nested.callback, callback);
+        assert.equal(document.nested.state, 'before');
+        assert.equal(document.list[0].state, 'before');
+        assert.equal(document.nullPrototype.state, 'before');
+        assert.equal(document.leaf, leaf);
+        assert.equal(document.self, document);
     });
 
     it('leaves the stdout transport unbatched', async function () {

--- a/packages/metrics/test/metrics.test.js
+++ b/packages/metrics/test/metrics.test.js
@@ -425,3 +425,350 @@ describe('Sampling', function () {
         assert.equal(write.secondCall.args[0].msg, 'Metric sampled-metric: 101 (sample rate: 0.5)');
     });
 });
+
+describe('Batching', function () {
+    afterEach(function () {
+        sandbox.restore();
+    });
+
+    function batchedMetrics(batch, metricsOptions) {
+        return new GhostMetrics({
+            metrics: {
+                transports: ['elasticsearch'],
+                batch,
+                ...metricsOptions,
+            },
+            elasticsearch: {
+                host: 'https://test-elasticsearch',
+                username: 'user',
+                password: 'pass',
+            },
+        });
+    }
+
+    it('is off by default', async function () {
+        const ghostMetrics = new GhostMetrics({ metrics: {} });
+        assert.equal(ghostMetrics.batch, null);
+        assert.deepEqual(ghostMetrics.batches, []);
+        assert.equal(new GhostMetrics().batch, null);
+        assert.equal(new GhostMetrics({ metrics: null }).batch, null);
+
+        // A no-op, so shutdown handlers can call it unconditionally
+        await assert.doesNotReject(() => new GhostMetrics().flush());
+    });
+
+    it('fills in defaults when enabled with `true`', function () {
+        assert.deepEqual(batchedMetrics(true).batch, {
+            size: 100,
+            maxWaitMs: 5000,
+            maxBufferSize: 1000,
+        });
+    });
+
+    it('accepts partial config, defaulting the buffer cap from the size', function () {
+        assert.deepEqual(batchedMetrics({ size: 10 }).batch, {
+            size: 10,
+            maxWaitMs: 5000,
+            maxBufferSize: 100,
+        });
+    });
+
+    it('treats false and an `enabled: false` bag as off', function () {
+        assert.equal(batchedMetrics(false).batch, null);
+        assert.equal(batchedMetrics({ enabled: false, size: 10 }).batch, null);
+    });
+
+    it('throws for invalid batch config', function () {
+        assert.throws(() => batchedMetrics('yes'), /metrics\.batch must be a boolean or an object/);
+        assert.throws(() => batchedMetrics([1]), /metrics\.batch must be a boolean or an object/);
+
+        for (const size of ['10', 0, -1, 1.5, NaN]) {
+            assert.throws(
+                () => batchedMetrics({ size }),
+                /metrics\.batch\.size must be a positive whole number/,
+            );
+        }
+
+        assert.throws(
+            () => batchedMetrics({ maxWaitMs: 0 }),
+            /metrics\.batch\.maxWaitMs must be a positive whole number/,
+        );
+        assert.throws(
+            () => batchedMetrics({ maxBufferSize: 0 }),
+            /metrics\.batch\.maxBufferSize must be a positive whole number/,
+        );
+        assert.throws(
+            () => batchedMetrics({ size: 10, maxBufferSize: 5 }),
+            /metrics\.batch\.maxBufferSize must be at least metrics\.batch\.size \(10\), got 5/,
+        );
+    });
+
+    it('buffers metrics and ships them in one bulk request', async function () {
+        const ghostMetrics = batchedMetrics({ size: 3 }, { metadata: { id: '123123' } });
+        const index = sandbox.stub(ElasticSearch.prototype, 'index').resolves();
+        const bulk = sandbox.stub(ElasticSearch.prototype, 'bulk').resolves();
+
+        await ghostMetrics.metric('cache-hit', 1);
+        await ghostMetrics.metric('cache-miss', 2);
+
+        // Nothing shipped yet, and never one request per metric
+        assert.equal(bulk.called, false);
+        assert.equal(index.called, false);
+
+        await ghostMetrics.metric('cache-hit', 3);
+        await ghostMetrics.flush();
+
+        assert.equal(bulk.calledOnce, true);
+
+        const operations = bulk.firstCall.args[0];
+        assert.equal(operations.length, 3);
+        assert.deepEqual(
+            operations.map((operation) => operation.index),
+            ['metrics-cache-hit', 'metrics-cache-miss', 'metrics-cache-hit'],
+        );
+        assert.deepEqual(
+            operations.map((operation) => operation.document.value),
+            [1, 2, 3],
+        );
+        assert.equal(operations[0].document.metadata.id, '123123');
+        assert.notEqual(operations[0].document['@timestamp'], undefined);
+    });
+
+    it('ships a partial buffer on flush', async function () {
+        const ghostMetrics = batchedMetrics({ size: 100 });
+        const bulk = sandbox.stub(ElasticSearch.prototype, 'bulk').resolves();
+
+        await ghostMetrics.metric('cache-hit', 1);
+        await ghostMetrics.flush();
+
+        assert.equal(bulk.calledOnce, true);
+        assert.equal(bulk.firstCall.args[0].length, 1);
+
+        // Nothing left to ship
+        await ghostMetrics.flush();
+        assert.equal(bulk.calledOnce, true);
+    });
+
+    it('ships the buffer once the max wait elapses', async function () {
+        const clock = sandbox.useFakeTimers();
+        const ghostMetrics = batchedMetrics({ size: 100, maxWaitMs: 1000 });
+        const bulk = sandbox.stub(ElasticSearch.prototype, 'bulk').resolves();
+
+        await ghostMetrics.metric('cache-hit', 1);
+        assert.equal(bulk.called, false);
+
+        await clock.tickAsync(999);
+        assert.equal(bulk.called, false);
+
+        await clock.tickAsync(1);
+        assert.equal(bulk.calledOnce, true);
+        assert.equal(bulk.firstCall.args[0].length, 1);
+
+        // The timer isn't rearmed until the next metric arrives
+        await clock.tickAsync(5000);
+        assert.equal(bulk.calledOnce, true);
+
+        await ghostMetrics.metric('cache-hit', 2);
+        await clock.tickAsync(1000);
+        assert.equal(bulk.calledTwice, true);
+    });
+
+    it('does not rearm the max wait timer for every metric', async function () {
+        const clock = sandbox.useFakeTimers();
+        const ghostMetrics = batchedMetrics({ size: 100, maxWaitMs: 1000 });
+        const bulk = sandbox.stub(ElasticSearch.prototype, 'bulk').resolves();
+
+        await ghostMetrics.metric('cache-hit', 1);
+        await clock.tickAsync(900);
+        await ghostMetrics.metric('cache-hit', 2);
+        await clock.tickAsync(100);
+
+        // The second metric didn't push the first one's deadline out
+        assert.equal(bulk.calledOnce, true);
+        assert.equal(bulk.firstCall.args[0].length, 2);
+    });
+
+    it('drops metrics once the buffer cap is reached', async function () {
+        const ghostMetrics = batchedMetrics({ size: 2, maxBufferSize: 4 });
+        // Never settles, so nothing can drain behind the first batch
+        sandbox.stub(ElasticSearch.prototype, 'bulk').returns(new Promise(() => {}));
+
+        for (let i = 0; i < 10; i += 1) {
+            await ghostMetrics.metric('cache-hit', i);
+        }
+
+        const [batch] = ghostMetrics.batches;
+        // Two metrics are in flight, four are buffered, the rest are shed
+        assert.equal(batch.buffer.length, 4);
+        assert.equal(batch.dropped, 4);
+    });
+
+    it('keeps only one bulk request in flight', async function () {
+        const ghostMetrics = batchedMetrics({ size: 2 });
+        let resolveFirst;
+        const bulk = sandbox
+            .stub(ElasticSearch.prototype, 'bulk')
+            .onFirstCall()
+            .returns(
+                new Promise((resolve) => {
+                    resolveFirst = resolve;
+                }),
+            )
+            .onSecondCall()
+            .resolves();
+
+        await ghostMetrics.metric('cache-hit', 1);
+        await ghostMetrics.metric('cache-hit', 2);
+        assert.equal(bulk.calledOnce, true);
+
+        await ghostMetrics.metric('cache-hit', 3);
+        await ghostMetrics.metric('cache-hit', 4);
+
+        // The second batch waits behind the first
+        assert.equal(bulk.calledOnce, true);
+
+        resolveFirst();
+        await ghostMetrics.flush();
+
+        assert.equal(bulk.calledTwice, true);
+        assert.equal(bulk.secondCall.args[0].length, 2);
+    });
+
+    it('queues a full buffer while another bulk request is in flight', async function () {
+        const clock = sandbox.useFakeTimers();
+        const ghostMetrics = batchedMetrics({ size: 2, maxWaitMs: 1000 });
+        let resolveFirst;
+        const bulk = sandbox
+            .stub(ElasticSearch.prototype, 'bulk')
+            .onFirstCall()
+            .returns(
+                new Promise((resolve) => {
+                    resolveFirst = resolve;
+                }),
+            )
+            .onSecondCall()
+            .resolves();
+
+        await ghostMetrics.metric('cache-hit', 1);
+        await ghostMetrics.metric('cache-hit', 2);
+        await ghostMetrics.metric('cache-hit', 3);
+        await ghostMetrics.metric('cache-hit', 4);
+
+        assert.equal(bulk.calledOnce, true);
+
+        resolveFirst();
+        await ghostMetrics.flush();
+
+        // The full second buffer is already queued; it does not wait for its timer.
+        assert.equal(clock.now, 0);
+        assert.equal(bulk.calledTwice, true);
+        assert.equal(bulk.secondCall.args[0].length, 2);
+    });
+
+    it('keeps shipping after a failed batch', async function () {
+        const ghostMetrics = batchedMetrics({ size: 1 });
+        const bulk = sandbox.stub(ElasticSearch.prototype, 'bulk');
+        bulk.onFirstCall().rejects(new Error('boom'));
+        bulk.onSecondCall().resolves();
+
+        await assert.doesNotReject(() => ghostMetrics.metric('cache-hit', 1));
+        await ghostMetrics.flush();
+
+        await ghostMetrics.metric('cache-hit', 2);
+        await ghostMetrics.flush();
+
+        assert.equal(bulk.calledTwice, true);
+    });
+
+    it('drops batched metrics that fall outside the sample rate', async function () {
+        const ghostMetrics = batchedMetrics({ size: 1 }, { sampleRate: 0.1 });
+        const bulk = sandbox.stub(ElasticSearch.prototype, 'bulk').resolves();
+        sandbox.stub(Math, 'random').returns(0.5);
+
+        await ghostMetrics.metric('cache-hit', 1);
+        await ghostMetrics.flush();
+
+        assert.equal(bulk.called, false);
+    });
+
+    it('tags batched documents with the sample rate they survived', async function () {
+        const ghostMetrics = batchedMetrics({ size: 1 }, { sampleRate: 0.5 });
+        const bulk = sandbox.stub(ElasticSearch.prototype, 'bulk').resolves();
+        sandbox.stub(Math, 'random').returns(0.1);
+
+        await ghostMetrics.metric('cache-hit', 1);
+        await ghostMetrics.flush();
+
+        assert.equal(bulk.firstCall.args[0][0].document.sampleRate, 0.5);
+    });
+
+    it('copies object values so a buffered document cannot be mutated', async function () {
+        const metadata = { site: { id: 'original' } };
+        const ghostMetrics = batchedMetrics({ size: 100 }, { metadata });
+        const bulk = sandbox.stub(ElasticSearch.prototype, 'bulk').resolves();
+
+        const value = { operation: 'get', result: { source: 'cache' } };
+        await ghostMetrics.metric('cache-error', value);
+        value.operation = 'set';
+        value.result.source = 'database';
+        metadata.site.id = 'changed';
+
+        await ghostMetrics.flush();
+
+        assert.equal(bulk.firstCall.args[0][0].document.operation, 'get');
+        assert.equal(bulk.firstCall.args[0][0].document.result.source, 'cache');
+        assert.equal(bulk.firstCall.args[0][0].document.metadata.site.id, 'original');
+        // The caller's object is left alone
+        assert.deepEqual(Object.keys(value), ['operation', 'result']);
+    });
+
+    it('honours a pre-set timestamp and shipping without metadata', async function () {
+        const ghostMetrics = batchedMetrics({ size: 1 });
+        ghostMetrics.metadata = null;
+        const bulk = sandbox.stub(ElasticSearch.prototype, 'bulk').resolves();
+
+        await ghostMetrics.metric('object-metric', { value: 101, '@timestamp': 12345 });
+        await ghostMetrics.flush();
+
+        assert.deepEqual(bulk.firstCall.args[0][0].document, { value: 101, '@timestamp': 12345 });
+    });
+
+    it('wraps non-object values, including null and arrays', async function () {
+        const ghostMetrics = batchedMetrics({ size: 100 });
+        const bulk = sandbox.stub(ElasticSearch.prototype, 'bulk').resolves();
+
+        await ghostMetrics.metric('null-metric', null);
+        await ghostMetrics.metric('array-metric', [1, 2]);
+        await ghostMetrics.flush();
+
+        const [nullOperation, arrayOperation] = bulk.firstCall.args[0];
+        assert.equal(nullOperation.document.value, null);
+        assert.deepEqual(arrayOperation.document.value, [1, 2]);
+    });
+
+    it('does not throw when a metric value cannot be deeply cloned', async function () {
+        const ghostMetrics = batchedMetrics({ size: 1 });
+        const bulk = sandbox.stub(ElasticSearch.prototype, 'bulk').resolves();
+        const value = { callback: () => 'not cloneable' };
+
+        await assert.doesNotReject(() => ghostMetrics.metric('callback-metric', value));
+        await ghostMetrics.flush();
+
+        assert.equal(bulk.firstCall.args[0][0].document.callback, value.callback);
+    });
+
+    it('leaves the stdout transport unbatched', async function () {
+        const write = sandbox.stub(PrettyStream.prototype, 'write');
+        const ghostMetrics = new GhostMetrics({
+            metrics: {
+                transports: ['stdout'],
+                batch: { size: 100 },
+            },
+        });
+
+        await ghostMetrics.metric('cache-hit', 1);
+
+        assert.equal(write.calledOnce, true);
+        assert.deepEqual(ghostMetrics.batches, []);
+    });
+});


### PR DESCRIPTION
no ref

The Elasticsearch metric transport makes one HTTP request per metric. That showed up in a CPU profile of Ghost as a large number of shipping calls from hot paths such as redis cache lookups.

Sampling cut how many metrics get shipped. This cuts how many *requests* they cost: documents are buffered and shipped through the bulk API, so a hot path costs one request per batch instead of one per metric.

## Usage

Off by default. Opt in with `metrics.batch` — `true` for the defaults, or an object to override them:

```js
new GhostMetrics({
    metrics: {
        transports: ['elasticsearch'],
        batch: {size: 500, maxWaitMs: 2000},
    },
});
```

| Option | Default | Meaning |
| --- | --- | --- |
| `enabled` | `true` | Set to `false` to turn batching off without dropping the rest of the config |
| `size` | `100` | Buffered documents that trigger a bulk request |
| `maxWaitMs` | `5000` | How long a document may sit in the buffer before it is shipped |
| `maxBufferSize` | `size * 10` | Hard cap on buffered documents; further metrics are dropped |

In Ghost this is reachable through config as `logging.metrics.batch`, since `loggingrc.js` already passes `logging:metrics` straight through — no Ghost code change needed to turn it on, once a release lands.

## How it composes with sampling

Sampling runs in `metric()` before any shipper is called, so a metric that loses the coin flip is never buffered — the buffer only holds survivors. The surviving rate is then passed to the same `buildDocument()` the unbatched path uses, so batched documents carry the `sampleRate` field exactly as before. The two multiply: `sampleRate: 0.01` with `size: 100` is one bulk request per ~10,000 calls.

## Behaviour changes when batching is on

- `metric()` resolves once the metric is **buffered**, not once it has shipped. It was already fire-and-forget for essentially every caller, but a caller that awaited delivery no longer gets it.
- Buffered metrics are lost if the process exits without draining, so `GhostMetrics.flush()` is added for shutdown handlers. It is a no-op when batching is off, so it is always safe to call.

Both are no-ops when batching is off, which is the default — nothing changes for existing consumers.

## Safety

- The buffer is bounded. At `maxBufferSize` it sheds load rather than growing the heap while Elasticsearch is slow or down; the drop count is readable off the instance.
- Only one bulk request is ever in flight; batches queue behind each other rather than stampeding.
- A failed batch is dropped without rejecting, so a metric call can never break the code path it is measuring.
- The max-wait timer is unreffed, so a partially full buffer cannot hold the process open.
- Documents are copied rather than mutated, so a buffered document can't be changed by the caller after the fact. This also fixes `metric()` throwing on a `null` value.

## Also here

`ElasticSearch.bulk()` in `@tryghost/elasticsearch`, which the batched transport ships through. It uses the `create` action, matching the existing Bunyan bulk path, so it works against data streams as well as regular indices.

## Testing

61 tests across the two packages, 100% branch coverage on both. `pnpm lint` and `pnpm format:check` clean. No dependency or lockfile changes.

## Follow-up

Ghost needs a catalog bump to a release carrying this, plus a `metrics.flush()` call in the shutdown drain (`ghost/core/core/shared/flush-logs.ts`) before batching is turned on there. Not included here since it depends on an unpublished version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SQ6sWj3nDec6tcRyxx1t1H

---
_Generated by [Claude Code](https://claude.ai/code/session_01SQ6sWj3nDec6tcRyxx1t1H)_