### PR TITLE
🎨 Removed prometheus metrics server from default export

### DIFF
--- a/packages/prometheus-metrics/README.md
+++ b/packages/prometheus-metrics/README.md
@@ -8,6 +8,21 @@ Prometheus metrics integration for exposing Ghost runtime counters, gauges, and 
 
 ## Usage
 
+Import the metrics client from the package root:
+
+```ts
+import { PrometheusClient } from '@tryghost/prometheus-metrics';
+```
+
+The standalone server is available separately:
+
+```ts
+import { MetricsServer } from '@tryghost/prometheus-metrics/server';
+```
+
+Install Express 4 or 5 in your application when using `MetricsServer`. Express is
+an optional peer dependency and is not loaded by the package root.
+
 ## Develop
 
 This is a monorepo package.

--- a/packages/prometheus-metrics/package.json
+++ b/packages/prometheus-metrics/package.json
@@ -12,6 +12,23 @@
   ],
   "main": "build/index.js",
   "types": "build/index.d.ts",
+  "typesVersions": {
+    "*": {
+      "server": [
+        "build/server.d.ts"
+      ]
+    }
+  },
+  "exports": {
+    ".": {
+      "types": "./build/index.d.ts",
+      "default": "./build/index.js"
+    },
+    "./server": {
+      "types": "./build/server.d.ts",
+      "default": "./build/server.js"
+    }
+  },
   "publishConfig": {
     "access": "public"
   },
@@ -28,7 +45,6 @@
   "dependencies": {
     "@tryghost/debug": "workspace:^",
     "@tryghost/logging": "workspace:^",
-    "express": "^5.2.1",
     "prom-client": "^15.1.3",
     "stoppable": "^1.1.0"
   },
@@ -38,10 +54,19 @@
     "@types/sinon": "22.0.0",
     "@types/stoppable": "1.1.3",
     "@types/supertest": "7.2.1",
+    "express": "^5.2.1",
     "knex": "3.3.0",
     "nock": "14.0.17",
     "sinon": "catalog:",
     "supertest": "7.2.2",
     "typescript": "catalog:"
+  },
+  "peerDependencies": {
+    "express": "^4.0.0 || ^5.0.0"
+  },
+  "peerDependenciesMeta": {
+    "express": {
+      "optional": true
+    }
   }
 }

--- a/packages/prometheus-metrics/src/PrometheusClient.ts
+++ b/packages/prometheus-metrics/src/PrometheusClient.ts
@@ -1,4 +1,4 @@
-import { Request, Response } from 'express';
+import type { Request, Response } from 'express';
 import http from 'http';
 import client from 'prom-client';
 import type { Metric, MetricObjectWithValues, MetricValue } from 'prom-client';

--- a/packages/prometheus-metrics/src/index.ts
+++ b/packages/prometheus-metrics/src/index.ts
@@ -1,2 +1,1 @@
-export * from './MetricsServer';
 export * from './PrometheusClient';

--- a/packages/prometheus-metrics/src/server.ts
+++ b/packages/prometheus-metrics/src/server.ts
@@ -1,0 +1,1 @@
+export * from './MetricsServer';

--- a/packages/prometheus-metrics/test/metrics-server.test.ts
+++ b/packages/prometheus-metrics/test/metrics-server.test.ts
@@ -1,5 +1,5 @@
 import assert from 'assert/strict';
-import { MetricsServer } from '../src';
+import { MetricsServer } from '../src/server';
 import express from 'express';
 import * as sinon from 'sinon';
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -714,9 +714,6 @@ importers:
       '@tryghost/logging':
         specifier: workspace:^
         version: link:../logging
-      express:
-        specifier: ^5.2.1
-        version: 5.2.1(supports-color@8.1.1)
       prom-client:
         specifier: ^15.1.3
         version: 15.1.3
@@ -739,6 +736,9 @@ importers:
       '@types/supertest':
         specifier: 7.2.1
         version: 7.2.1
+      express:
+        specifier: ^5.2.1
+        version: 5.2.1(supports-color@8.1.1)
       knex:
         specifier: 3.3.0
         version: 3.3.0(sqlite3@6.0.1)(supports-color@8.1.1)


### PR DESCRIPTION
no ref
- move metrics server export to `/server` subpath
- make express a peer dependency reducing duplicate versions